### PR TITLE
Get rid of Only variables should be passed by reference for PHP 7

### DIFF
--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -99,12 +99,14 @@ class MarketController extends Controller {
 			if ($app['installed']) {
 				$app['installInfo'] = $this->marketService->getInstalledAppInfo($app['id']);
 				$app['updateInfo'] = $this->marketService->getAvailableUpdateVersion($app['id']);
-				$app['release'] = array_pop(array_filter($releases, function ($release) use ($app) {
+				
+				$filteredReleases = array_filter($releases, function ($release) use ($app) {
 					if (empty($app['updateInfo'])) {
 						return $release['version'] === $app['updateInfo'];
 					}
 					return $release['version'] === $app['updateInfo'];
-				}));
+				});
+				$app['release'] = array_pop($filteredReleases);
 			} else {
 				$app['updateInfo'] = [];
 				usort($releases, function ($a, $b) {


### PR DESCRIPTION
0. Install OC 10. Environment: PHP 7.0
1. Install app from market
2. Browse to the market page again, when app is installed.
3. tail `data/owncloud.log`
```
> tail data/owncloud.log      

{"reqId":"JP5lXdGK9RWCvRUCoVpU","level":3,"time":"2017-04-19T19:56:17+00:00","remoteAddr":"127.0.0.1","user":"D","app":"PHP","method":"GET","url":"/index.php/apps/market/apps","message":"Only variables should be passed by reference at /apps/market/lib/Controller/MarketController.php#107"}

```