### PR TITLE
Skip migrations when reinstalling missing code

### DIFF
--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -42,6 +42,7 @@ class Listener {
 	}
 
 	public function reinstallAppStoreApp($app){
-		$this->marketService->installApp($app);
+		// only reinstall the code, do not run migrations
+		$this->marketService->installApp($app,  true);
 	}
 }

--- a/lib/MarketService.php
+++ b/lib/MarketService.php
@@ -73,10 +73,11 @@ class MarketService {
 	 * Install an app for the given app id
 	 *
 	 * @param string $appId
+	 * @param bool $skipMigrations whether to skip migrations
 	 * @throws AppAlreadyInstalledException
 	 * @throws AppManagerException
 	 */
-	public function installApp($appId) {
+	public function installApp($appId, $skipMigrations = false) {
 		try {
 			$info = $this->getInstalledAppInfo($appId);
 			if (!is_null($info)) {
@@ -85,7 +86,7 @@ class MarketService {
 
 			// download package
 			$package = $this->downloadPackage($appId);
-			$this->installPackage($package);
+			$this->installPackage($package, $skipMigrations);
 			$this->appManager->enableApp($appId);
 		} catch (ClientException $e){
 			throw new AppManagerException('No marketplace connection', 0, $e);
@@ -96,11 +97,12 @@ class MarketService {
 
 	/**
 	 * Install downloaded package
-	 * @param string $package
+	 * @param string $package package path
+	 * @param bool $skipMigrations whether to skip migrations
 	 * @return string appId
 	 */
-	public function installPackage($package){
-		return $this->appManager->installApp($package);
+	public function installPackage($package, $skipMigrations = false){
+		return $this->appManager->installApp($package, $skipMigrations);
 	}
 
 	/**


### PR DESCRIPTION
Because the app was already installed, no migrations must be run at this
stage. Later on, the upgrade process might notice a version change and
run migrations anyway. This part ensures it doesn't happen twice during
the upgrade process.

- [ ] Requires https://github.com/owncloud/core/pull/27934

Tested as follows:

1. Install 9.1.5 enterprise
1. Enable user_ldap
1. Replace the source code with OC 10.0.1RC1 enterprise from tarball
1. Patch with https://github.com/owncloud/core/pull/27930
1. Patch with https://github.com/owncloud/core/pull/27934
1. Patch with this PR here
1. Edit config.php to point to the correct cert and staging marketplace (if applicable, need the user_ldap app to be there)
1. Run `occ upgrade`

Before the fixes: LDAP migrations run twice and getting TableAlreadyExistsException because it tries to create the same tables twice.
After the fix: upgrade went through! LDAP app still enabled.