### PR TITLE
Skip migrations with CLI market app intall

### DIFF
--- a/lib/Command/InstallApp.php
+++ b/lib/Command/InstallApp.php
@@ -81,7 +81,7 @@ class InstallApp extends Command {
 						}
 					} else {
 						$output->writeln("$appId: Installing new app from $localPackage");
-						$this->marketService->installPackage($localPackage);
+						$this->marketService->installPackage($localPackage, true);
 						$output->writeln("$appId: App installed.");
 					}
 				} catch (\Exception $ex) {

--- a/lib/Command/InstallApp.php
+++ b/lib/Command/InstallApp.php
@@ -102,7 +102,7 @@ class InstallApp extends Command {
 						}
 					} else {
 						$output->writeln("$appId: Installing new app ...");
-						$this->marketService->installApp($appId);
+						$this->marketService->installApp($appId, true);
 						$output->writeln("$appId: App installed.");
 					}
 				} catch (\Exception $ex) {


### PR DESCRIPTION
@butonic @davitol 

need to make sure it works for apps that have database.xml DB code (old) and new-style migrations

user_ldap uses database.xml
customgroups uses migrations
