### PR TITLE
Sort occ market:list in alphabetical order

### DIFF
--- a/lib/Command/ListApps.php
+++ b/lib/Command/ListApps.php
@@ -44,6 +44,11 @@ class ListApps extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$apps = $this->marketService->listApps();
+
+		usort($apps, function ($a, $b) {
+			return strcmp($a['id'], $b['id']);
+		});
+
 		foreach ($apps as $app) {
 			$output->writeln("{$app['id']}");
 		}


### PR DESCRIPTION
I was just using the command line occ market commands. The output of market:list comes out in whatever order the JSON happens to have been delivered in.

This output is intended for human consumption (as well as the possibility that someone will write a script that eats it), so it is friendly to sort it alphabetically.

One day it could be enhanced to group the list by category, and that will require a different sorting.

I thought about putting the sorting inside listApps(). But actually each caller of listApps() might want sorting by all sorts of different fields, not necessarily by id.