### PR TITLE
Error messages for marketplace errors

### DIFF
--- a/lib/MarketService.php
+++ b/lib/MarketService.php
@@ -108,21 +108,16 @@ class MarketService {
 			}
 		}
 
-		try {
-			$info = $this->getInstalledAppInfo($appId);
-			if (!is_null($info)) {
-				throw new AppAlreadyInstalledException($this->l10n->t('App %s is already installed', $appId));
-			}
 
-			// download package
-			$package = $this->downloadPackage($appId);
-			$this->installPackage($package, $skipMigrations);
-			$this->appManager->enableApp($appId);
-		} catch (ClientException $e){
-			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
-		} catch (ServerException $e){
-			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
+		$info = $this->getInstalledAppInfo($appId);
+		if (!is_null($info)) {
+			throw new AppAlreadyInstalledException($this->l10n->t('App %s is already installed', $appId));
 		}
+
+		// download package
+		$package = $this->downloadPackage($appId);
+		$this->installPackage($package, $skipMigrations);
+		$this->appManager->enableApp($appId);
 	}
 
 	/**
@@ -172,8 +167,15 @@ class MarketService {
 		$pathInfo = pathinfo($downloadLink);
 		$extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
 		$path = \OC::$server->getTempManager()->getTemporaryFile($extension);
-		$this->httpGet($downloadLink, ['save_to' => $path]);
-
+		try {
+			$this->httpGet($downloadLink, ['save_to' => $path]);
+		} catch (ClientException $e) {
+			// product requires a purchase
+			if ($e->getCode() === 402) {
+				throw new AppManagerException($this->l10n->t('Active subscription on marketplace required'));
+			}
+			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
+		}
 		return $path;
 	}
 
@@ -259,20 +261,14 @@ class MarketService {
 			throw new \Exception("Installing apps is not supported because the app folder is not writable.");
 		}
 
-		try {
-			$info = $this->getInstalledAppInfo($appId);
-			if (is_null($info)) {
-				throw new AppNotInstalledException($this->l10n->t('App (%s) is not installed', $appId));
-			}
-
-			// download package
-			$package = $this->downloadPackage($appId);
-			$this->updatePackage($package);
-		} catch (ClientException $e){
-			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
-		} catch (ServerException $e){
-			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
+		$info = $this->getInstalledAppInfo($appId);
+		if (is_null($info)) {
+			throw new AppNotInstalledException($this->l10n->t('App (%s) is not installed', $appId));
 		}
+
+		// download package
+		$package = $this->downloadPackage($appId);
+		$this->updatePackage($package);
 	}
 
 	/**
@@ -469,7 +465,19 @@ class MarketService {
 			], $options);
 		}
 		$client = \OC::$server->getHTTPClientService()->newClient();
-		$response = $client->get($path, $options);
+		try {
+			$response = $client->get($path, $options);
+		} catch (ClientException $e) {
+			if ($e->getCode() === 401) {
+				if ($apiKey !== null) {
+					throw new AppManagerException($this->l10n->t('Invalid marketplace API key provided'));
+				}
+				throw new AppManagerException($this->l10n->t('Marketplace API key missing'));
+			}
+			throw $e;
+		} catch (ServerException $e) {
+			throw new AppManagerException($this->l10n->t('No marketplace connection'), 0, $e);
+		}
 		return $response;
 	}
 


### PR DESCRIPTION
This PR adresses #133  - market app only shows `No marketplace connection` even though we are having different (actionable) error cases:

1) No api key provided, and trying to download an application that is not free to download
2) Invalid API Key provided
3) Valid Api Key, but product is not purchased on marketplace (no valid subscription)

## Fixed behavior:

1) **No api key provided**
```
php occ market:upgrade theme-enterprise
theme-enterprise: Installing new version 2.0.0 ...
theme-enterprise: Marketplace API key missing
```
Frontend shows
<img width="404" alt="apikeymissing" src="https://user-images.githubusercontent.com/6403243/30053858-79d2b1d4-922a-11e7-8d99-dedde8cc6de6.png">

2) ** Invalid APIKEY**

```
$ php occ market:upgrade theme-enterprise
theme-enterprise: Invalid marketplace API key provided
```
<img width="388" alt="invalid apikey" src="https://user-images.githubusercontent.com/6403243/30054019-fbd44b3e-922a-11e7-86d5-fd74c64ec249.png">

3) ** Purchase required**
```
php occ market:upgrade theme-enterprise
theme-enterprise: Installing new version 2.0.0 ...
theme-enterprise: Active subscription on marketplace required
```
<img width="395" alt="active_subscription_required" src="https://user-images.githubusercontent.com/6403243/30054013-f5f35e08-922a-11e7-94f8-7db334132cb7.png">


## Tested
- manually tested
- tipps for mocking `\OC::$server->getHTTPClientService()->newClient();` appreciated - then I can write unit tests with a mocked Client



Note: I am not sure about the texts used- maybe someone has a better message for any of those scenarios. Also was thinking of using the message Body that Marketplace provided. Suggestions?

Also help appreciated with providing translations
