### PR TITLE
provide non-zero exit codes on failure

### DIFF
--- a/lib/Command/InstallApp.php
+++ b/lib/Command/InstallApp.php
@@ -33,6 +33,9 @@ class InstallApp extends Command {
 	/** @var MarketService */
 	private $marketService;
 
+	/** @var int  */
+	private $exitCode = 0;
+
 	public function __construct(MarketService $marketService) {
 		parent::__construct();
 		$this->marketService = $marketService;
@@ -89,7 +92,8 @@ class InstallApp extends Command {
 						$output->writeln("$appId: App installed.");
 					}
 				} catch (\Exception $ex) {
-					$output->writeln("$appId: {$ex->getMessage()}");
+					$output->writeln("<error> $appId: {$ex->getMessage()} </error>");
+					$this->exitCode = 1;
 				}
 			}
 		} else {
@@ -110,9 +114,12 @@ class InstallApp extends Command {
 						$output->writeln("$appId: App installed.");
 					}
 				} catch (\Exception $ex) {
-					$output->writeln("$appId: {$ex->getMessage()}");
+					$output->writeln("<error> $appId: {$ex->getMessage()} </error>");
+					$this->exitCode = 1;
 				}
 			}
 		}
+
+		return $this->exitCode;
 	}
 }

--- a/lib/Command/ListApps.php
+++ b/lib/Command/ListApps.php
@@ -43,7 +43,12 @@ class ListApps extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$apps = $this->marketService->listApps();
+		try {
+			$apps = $this->marketService->listApps();
+		} catch (\Exception $ex) {
+			$output->writeln("<error>{$ex->getMessage()} </error>");
+			return 1;
+		}
 
 		usort($apps, function ($a, $b) {
 			return strcmp($a['id'], $b['id']);

--- a/lib/Command/UnInstallApp.php
+++ b/lib/Command/UnInstallApp.php
@@ -33,6 +33,9 @@ class UnInstallApp extends Command {
 	/** @var MarketService */
 	private $marketService;
 
+	/** @var int  */
+	private $exitCode = 0;
+
 	public function __construct(MarketService $marketService) {
 		parent::__construct();
 		$this->marketService = $marketService;
@@ -67,8 +70,10 @@ class UnInstallApp extends Command {
 				$this->marketService->uninstallApp($appId);
 				$output->writeln("$appId: App uninstalled.");
 			} catch (\Exception $ex) {
-				$output->writeln("$appId: {$ex->getMessage()}");
+				$output->writeln("<error>$appId: {$ex->getMessage()}</error>");
+				$this->exitCode = 1;
 			}
 		}
+		return $this->exitCode;
 	}
 }

--- a/lib/Command/UpgradeApp.php
+++ b/lib/Command/UpgradeApp.php
@@ -33,6 +33,9 @@ class UpgradeApp extends Command {
 	/** @var MarketService */
 	private $marketService;
 
+	/** @var int  */
+	private $exitCode = 0;
+
 	public function __construct(MarketService $marketService) {
 		parent::__construct();
 		$this->marketService = $marketService;
@@ -80,10 +83,11 @@ class UpgradeApp extends Command {
 						$output->writeln("$appId: Not installed ...");
 					}
 				} catch (\Exception $ex) {
-					$output->writeln("$appId: {$ex->getMessage()}");
+					$output->writeln("<error>$appId: {$ex->getMessage()}</error>");
+					$this->exitCode = 1;
 				}
 			}
-			return;
+			return $this->exitCode;
 		}
 
 		if ($input->getOption('list')) {
@@ -116,8 +120,10 @@ class UpgradeApp extends Command {
 					$output->writeln("$appId: Not installed ...");
 				}
 			} catch (\Exception $ex) {
-				$output->writeln("$appId: {$ex->getMessage()}");
+				$output->writeln("<error>$appId: {$ex->getMessage()}</error>");
+				$this->exitCode = 1;
 			}
 		}
+		return $this->exitCode;
 	}
 }


### PR DESCRIPTION
# Motivation
OCC market commands would always return 0 as exit code, even if a failure occured. This PR is related to #133 to provide non-zero exit codes (exit-code 1 on failure). When a failure occured

Tested manually:
```
$ php occ market:upgrade theme-enterprise
theme-enterprise: Installing new version 2.0.0 ...
theme-enterprise: No marketplace connection
$ echo $?
1
```

