### PR TITLE
added explicit js-beautify dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    ["es2015", {"modules": false}]
+    ["env", {"modules": false}]
   ]
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,9 @@
+{
+  "dependencies":
+  {
+    "js-beautify":
+    {
+      "version": "1.6.14"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "vue-style-loader": "1.0.0",
     "vue-template-compiler": "2.3.3",
     "vuex": "2.2.1",
-    "webpack": "2.6.1"
+    "webpack": "2.6.1",
+    "js-beautify": "1.6.14"
   },
   "bugs": {
     "url": "https://github.com/owncloud/market/issues"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "axios": "0.16.0",
-    "babel": "6.23.0",
+    "babel-cli": "6.26.0",
     "babel-core": "6.24.0",
     "babel-loader": "6.4.1",
     "babel-polyfill": "6.23.0",
-    "babel-preset-es2015": "6.24.0",
+    "babel-preset-env": "1.6.0",
     "css-loader": "0.27.3",
     "easygettext": "1.2.2",
     "expose-loader": "0.7.3",
@@ -37,11 +37,11 @@
     "less-loader": "4.0.3",
     "node-sass": "4.5.3",
     "npm-watch": "0.1.8",
-    "pug": "^2.0.0-beta9",
+    "pug": "2.0.0-beta9",
     "sass-loader": "6.0.5",
     "style-loader": "0.16.1",
     "uglify-js": "3.0.13",
-    "uikit": "^3.0.0-beta.28",
+    "uikit": "3.0.0-beta.30",
     "underscore": "1.8.3",
     "vue": "2.3.3",
     "vue-gettext": "2.0.14",
@@ -51,8 +51,7 @@
     "vue-style-loader": "1.0.0",
     "vue-template-compiler": "2.3.3",
     "vuex": "2.2.1",
-    "webpack": "2.6.1",
-    "js-beautify": "1.6.14"
+    "webpack": "2.6.1"
   },
   "bugs": {
     "url": "https://github.com/owncloud/market/issues"


### PR DESCRIPTION
One of our dependencies depends on an explicit old version of `js-beautify` which was deleted, this makes the build fail. Explicitly depending on a current version fixes this issue.

https://github.com/beautify-web/js-beautify/issues/1247