### PR TITLE
 Rebuild navigation after application (un)install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Show more detailed update information. [#159](https://github.com/owncloud/market/pull/159)
+
 
 ## [10.0.3 / 0.2.2] - 2017-09-15
 ### Added


### PR DESCRIPTION
This rebuilds the top left navigation and adds or removes apps whether they were just installed or deleted.

Since `OC.Settings.Apps` is only available in the settings section, I copied and slimed the `rebuildNavigation()` method in the market.

Fixes: https://github.com/owncloud/market/issues/170