### PR TITLE
Only create notifications for apps which are installed

### DIFF
--- a/lib/MarketService.php
+++ b/lib/MarketService.php
@@ -313,7 +313,7 @@ class MarketService {
 	 */
 	public function getUpdates() {
 		$result = [];
-		$apps = $this->appManager->getAllApps();
+		$apps = $this->appManager->getInstalledApps();
 		foreach ($apps as $app) {
 			$info = $this->appManager->getAppInfo($app);
 			if (isset($info['id'])) {


### PR DESCRIPTION
Otherwise the app manager returns appids for apps that are disabled - and these may also have been uninstalled. We should be safer and only explicitly ask for installed apps when considering updates.

Not sure what else is involved for market app development.

cc @dercorn who had this issue with the xmas app that he disabled but continually had a notification for.