### PR TITLE
Invalidate cache on change of apikey / enterprise trail

### DIFF
--- a/lib/MarketService.php
+++ b/lib/MarketService.php
@@ -415,7 +415,7 @@ class MarketService {
 	public function setApiKey($apiKey) {
 		if ($this->isApiKeyChangeableByUser()) {
 			$this->config->setAppValue('market', 'key', $apiKey);
-
+			$this->invalidateCache();
 			return true;
 		}
 
@@ -592,7 +592,7 @@ class MarketService {
 		}
 
 		$this->config->setAppValue('enterprise_key', 'license-key', $demoLicenseKey);
-
+		$this->invalidateCache();
 		return $demoLicenseKey;
 	}
 


### PR DESCRIPTION
Fixes #260 

When caching is active, the first request would be cached and if the apikey / enterprise trail is started afterward, it would lead to not being able to install enterprise trail apps

Note:
There is still an open scenario, that when the user changes config.php manually to update licensekey and apikey that the cache would persist.

We should document that changing/adding theses values requires a cache invalidation 