### PR TITLE
Prevent update notifications from uninstalled apps

### DIFF
--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -39,7 +39,6 @@ class Notifier implements INotifier {
 	/** @var IFactory */
 	protected $l10NFactory;
 
-
 	/**
 	 * Notifier constructor.
 	 *
@@ -73,6 +72,8 @@ class Notifier implements INotifier {
 		$appVersions = $this->getAppVersions();
 		if (isset($appVersions[$notification->getObjectType()])) {
 			$this->updateAlreadyInstalledCheck($notification, $appVersions[$notification->getObjectType()]);
+		} else {
+			throw new \InvalidArgumentException();
 		}
 
 		$notification->setParsedSubject(
@@ -85,14 +86,18 @@ class Notifier implements INotifier {
 	}
 
 	/**
-	 * Remove the notification and prevent rendering, when the update is installed
+	 * Remove the notification and prevent rendering,
+	 * when either the update is installed or app was removed
 	 *
 	 * @param INotification $notification
 	 * @param string $installedVersion
 	 * @throws \InvalidArgumentException When the update is already installed
 	 */
 	protected function updateAlreadyInstalledCheck(INotification $notification, $installedVersion) {
-		if (version_compare($notification->getObjectId(), $installedVersion, '<=')) {
+		if (
+			$this->appManager->getAppPath($notification->getObjectType()) === false
+			|| version_compare($notification->getObjectId(), $installedVersion, '<=')
+		) {
 			$this->notificationManager->markProcessed($notification);
 			throw new \InvalidArgumentException();
 		}

--- a/tests/unit/NotifierTest.php
+++ b/tests/unit/NotifierTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace OCA\Market\Tests\Unit;
+
+use OC\Notification\Notification;
+use OCA\Market\Notifier;
+use OCP\App\IAppManager;
+use OCP\L10N\IFactory;
+use OCP\IL10N;
+use OCP\Notification\IManager;
+use Test\TestCase;
+
+class NotifierTest extends TestCase {
+
+	protected $appManager;
+
+	protected $notificationManager;
+
+	protected $l10nFactory;
+
+	protected function setUp() {
+		parent::setUp();
+		$l10n = $this->getMockBuilder(IL10N::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$l10n->expects($this->any())
+			->method('t')
+			->willReturnArgument(0);
+
+		$this->l10nFactory = $this->getMockBuilder(IFactory::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->l10nFactory->expects($this->any())
+			->method('get')
+			->willReturn($l10n);
+
+		$this->notificationManager = $this->getMockBuilder(IManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testUnexistingAppsDoNotCreateNotifications() {
+		$appName = 'whatsapp';
+		$notifier = new Notifier($this->notificationManager, $this->appManager, $this->l10nFactory);
+		$notification = new Notification();
+		$notification->setApp('market');
+		$notification->setObject($appName, 55);
+		$notification->setSubject('Cu');
+		$notifier->prepare($notification, 'en');
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testUninstalledAppsDoNotCreateNotifications() {
+		$appName = 'whatsapp';
+		$notifier = $this->getMockBuilder(Notifier::class)
+			->setConstructorArgs([$this->notificationManager, $this->appManager, $this->l10nFactory])
+			->setMethods(['getAppVersions'])
+			->getMock();
+
+		$notifier->expects($this->any())
+			->method('getAppVersions')
+			->willReturn([$appName => '1.2.4']);
+
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with($appName)
+			->willReturn(false);
+
+		$notification = new Notification();
+		$notification->setApp('market');
+		$notification->setObject($appName, 55);
+		$notification->setSubject('Cu');
+		$notifier->prepare($notification, 'en');
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/owncloud/market/issues/270

Note: I see a code path that can trigger this behavior but was failed to reproduce it on my instance according to the steps from the issue:
 - You install an app
 - You enable and app
 - It utilises appconfig keys
 - You disable the app
 - An app update is published
 - Marketplace notifcation created for the admin
 - You uninstall the app (folder actually removed)
 - You dismiss the update notification

Now - everytime the marketplace update cron runs you get a notification for an update to an app that you have disabled AND uninstalled. Every time. Even if you dismiss.