### PR TITLE
Set max node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack": "2.7.0"
   },
   "engines": {
-    "node": ">= 6.9"
+    "node": ">=6.9 <=8"
   },
   "bugs": {
     "url": "https://github.com/owncloud/market/issues"


### PR DESCRIPTION
This is because we observed that neither node v4 nor node v10 can build fine.

I used node v8 locally and building works.