### PR TITLE
Refactor the app to allow choosing between next minor and major update

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -44,7 +44,15 @@ class Application extends App {
 			IRepairStep::class . '::upgradeAppStoreApp',
 			function ($event) use ($listener) {
 				if ($event instanceof GenericEvent) {
-					$listener->upgradeAppStoreApp($event->getSubject());
+					try {
+						$isMajorUpdate = $event->getArgument('isMajorUpdate');
+					} catch (\InvalidArgumentException $e) {
+						$isMajorUpdate = false;
+					}
+					$listener->upgradeAppStoreApp(
+						$event->getSubject(),
+						$isMajorUpdate
+					);
 				}
 			}
 		);

--- a/lib/CheckUpdateBackgroundJob.php
+++ b/lib/CheckUpdateBackgroundJob.php
@@ -89,8 +89,12 @@ class CheckUpdateBackgroundJob extends TimedJob {
 				'market.page.index'
 			);
 			$url .= '#/app/' . $appId;
-
-			$this->createNotifications($appId, $appInfo['version'], $url);
+			if ($appInfo['major'] !== false) {
+				$this->createNotifications($appId, $appInfo['major'], $url);
+			}
+			if ($appInfo['minor'] !== false) {
+				$this->createNotifications($appId, $appInfo['minor'], $url);
+			}
 		}
 	}
 

--- a/lib/Command/InstallApp.php
+++ b/lib/Command/InstallApp.php
@@ -58,7 +58,7 @@ class InstallApp extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|null|void
+	 * @return int|null
 	 * @throws \Exception
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -73,7 +73,7 @@ class InstallApp extends Command {
 
 		if (!count($localPackagesArray) && !count($appIds)){
 			$output->writeln("No appId or path to a local package specified. Nothing to do.");
-			return;
+			return $this->exitCode;
 		}
 
 		if (count($localPackagesArray)){
@@ -106,13 +106,14 @@ class InstallApp extends Command {
 			foreach ($appIds as $appId) {
 				try {
 					if ($this->marketService->isAppInstalled($appId)) {
-						$updateVersion = $this->marketService->getAvailableUpdateVersion($appId);
+						$updateVersions = $this->marketService->getAvailableUpdateVersions($appId);
+						$updateVersion = $updateVersions['minor'];
 						if ($updateVersion !== false) {
 							$output->writeln("$appId: Installing new version $updateVersion ...");
 							$this->marketService->updateApp($appId);
 							$output->writeln("$appId: App updated.");
 						} else {
-							$output->writeln("$appId: App already installed and no update available");
+							$output->writeln("$appId: App already installed and no minor update available");
 						}
 					} else {
 						$output->writeln("$appId: Installing new app ...");

--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -221,46 +221,63 @@ class MarketController extends Controller {
 	protected function queryData($category = null) {
 		$apps = $this->marketService->listApps($category);
 
-		return array_map(function ($app) {
+		$apps = array_map(function ($app) {
 			return $this->enrichApp($app);
 		}, $apps);
+		return $apps;
 	}
 
 	private function enrichApp($app) {
 		$app['installed'] = $this->marketService->isAppInstalled($app['id']);
-		$releases = array_map(function ($release) {
-			$missing = $this->marketService->getMissingDependencies($release);
-			$release['canInstall'] = empty($missing);
-			$release['missingDependencies'] = $missing;
-			return $release;
-		}, $app['releases']);
+		$releases = array_map(
+			function ($release) {
+				$missing = $this->marketService->getMissingDependencies($release);
+				$release['canInstall'] = empty($missing);
+				$release['missingDependencies'] = $missing;
+				return $release;
+			},
+			$app['releases']
+		);
 		unset($app['releases']);
+
+		$app['minorUpdate'] = false;
+		$app['majorUpdate'] = false;
 		if ($app['installed']) {
 			$app['installInfo'] = $this->marketService->getInstalledAppInfo($app['id']);
-			$app['updateInfo'] = $this->marketService->getAvailableUpdateVersion($app['id']);
-
-			$filteredReleases = array_filter($releases, function ($release) use ($app) {
-				if (empty($app['updateInfo'])) {
-					return $release['version'] === $app['updateInfo'];
+			$app['updateInfo'] = $this->marketService->getAvailableUpdateVersions($app['id']);
+			$app['updateTo'] = $app['updateInfo']['minor'] !== false
+				? $app['updateInfo']['minor']
+				: $app['updateInfo']['major'];
+			array_walk(
+				$releases,
+				function ($release) use (&$app) {
+					if ($release['version'] === $app['updateInfo']['major']) {
+						$app['majorUpdate'] = $release;
+					}
+					if ($release['version'] === $app['updateInfo']['minor']) {
+						$app['minorUpdate'] = $release;
+					}
 				}
-				return $release['version'] === $app['updateInfo'];
-			});
-			$app['release'] = array_pop($filteredReleases);
+			);
 		} else {
-			$app['updateInfo'] = false;
-			usort($releases, function ($a, $b) {
-				return version_compare($a['version'], $b['version'], '>');
-			});
+			usort(
+				$releases,
+				function ($a, $b) {
+					return version_compare($a['version'], $b['version'], '>');
+				}
+			);
 			if (!empty($releases)) {
 				$app['release'] = array_pop($releases);
 			}
 		}
+		$app['updateInfo'] = $app['majorUpdate'] !== false || $app['minorUpdate'] !== false;
 		return $app;
 	}
 
 	/**
-	 * @return string
 	 * @NoCSRFRequired
+	 *
+	 * @return DataResponse
 	 */
 	public function getConfig() {
 		$licenseKeyAvailable = $this->marketService->hasLicenseKey();

--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -174,7 +174,6 @@ class MarketController extends Controller {
 	 * @return array|mixed
 	 */
 	public function getApiKey() {
-
 		return new DataResponse( [
 			'apiKey' => $this->marketService->getApiKey(),
 			'changeable' => $this->marketService->isApiKeyChangeableByUser(),

--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -202,15 +202,17 @@ class MarketController extends Controller {
 	 * @return array | DataResponse
 	 */
 	public function update($appId) {
+		$targetVersion = $this->request->getParam('toVersion');
 		try {
-			$this->marketService->updateApp($appId);
+			$this->marketService->updateApp($appId, $targetVersion);
 			return [
 				'message' => $this->l10n->t('App %s updated successfully', $appId)
 			];
 		} catch(\Exception $ex) {
-			return new DataResponse([
-				'message' => $ex->getMessage()
-			], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(
+				['message' => $ex->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
 		}
 	}
 

--- a/lib/HttpService.php
+++ b/lib/HttpService.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubinuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Market;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\TransferException;
+use OCP\App\AppManagerException;
+use OCP\Http\Client\IClientService;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\Util;
+
+/**
+ * Class HttpService
+ *
+ * @package OCA\Market
+ */
+class HttpService {
+	const CACHE_KEY = 'ocmp';
+
+	const APPS = 'apps_%s';
+	const BUNDLES = 'bundles';
+	const CATEGORIES = 'categories';
+	const DEMO_KEY = 'demo_license_information';
+
+	private $urlConfig = [
+		self::APPS => '/api/v1/platform/%s/apps.json',
+		self::BUNDLES => '/api/v1/bundles.json',
+		self::CATEGORIES => '/api/v1/categories.json',
+		self::DEMO_KEY => '/api/v1/instance/%s/demo-key'
+	];
+
+	/** @var IClientService */
+	private $httpClientService;
+	/** @var ICacheFactory */
+	private $cacheFactory;
+	/** @var IConfig */
+	private $config;
+	/** @var IL10N */
+	private $l10n;
+
+	/**
+	 * Service constructor.
+	 *
+	 * @param IClientService $httpClientService
+	 * @param IConfig $config
+	 * @param ICacheFactory $cacheFactory
+	 * @param IL10N $l10n
+	 */
+	public function __construct(
+		IClientService $httpClientService,
+		IConfig $config,
+		ICacheFactory $cacheFactory,
+		IL10N $l10n
+	) {
+		$this->httpClientService = $httpClientService;
+		$this->config = $config;
+		$this->cacheFactory = $cacheFactory;
+		$this->l10n = $l10n;
+	}
+
+	/**
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	public function getApps() {
+		return $this->getEntities(self::APPS);
+	}
+
+	/**
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	public function getBundles() {
+		return $this->getEntities(self::BUNDLES);
+	}
+
+	/**
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	public function getCategories() {
+		return $this->getEntities(self::CATEGORIES);
+	}
+
+	/**
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	public function getDemoKey() {
+		return $this->getEntities(self::DEMO_KEY);
+	}
+
+	/**
+	 * @param string $url
+	 * @param string $path
+	 *
+	 * @throws AppManagerException
+	 */
+	public function downloadApp($url, $path) {
+		$apiKey = $this->getApiKey();
+		$this->httpGet($url, ['save_to' => $path], $apiKey);
+	}
+
+	/**
+	 * @param string $apiKey
+	 *
+	 * @return \OCP\Http\Client\IResponse
+	 *
+	 * @throws AppManagerException
+	 */
+	public function validateKey($apiKey) {
+		$url = $this->getAbsoluteUrl('/api/v1/categories.json');
+		return $this->httpGet($url, [], $apiKey);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function invalidateCache() {
+		if (!$this->cacheFactory->isAvailable()) {
+			return;
+		}
+		$cache = $this->cacheFactory->create(self::CACHE_KEY);
+		$cache->clear();
+	}
+
+	/**
+	 * @param string $key
+	 * @param string $uri
+	 *
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	public function queryData($key, $uri) {
+		// read from cache
+		if ($this->cacheFactory->isAvailable()) {
+			$cache = $this->cacheFactory->create(self::CACHE_KEY);
+			$data = $cache->get($key);
+			if ($data !== null) {
+				return json_decode($data, true);
+			}
+		}
+
+		$this->checkInternetConnection();
+		$apiKey = $this->getApiKey();
+		$endpointUrl = $this->getAbsoluteUrl($uri);
+		$response = $this->httpGet($endpointUrl, [], $apiKey);
+		$data = $response->getBody();
+		if ($this->cacheFactory->isAvailable()) {
+			// cache if for a day - TODO: evaluate the response header
+			$cache = $this->cacheFactory->create(self::CACHE_KEY);
+			$cache->set($key, $data, 60 * 60 * 24);
+		}
+		return json_decode($data, true);
+	}
+
+	/**
+	 * Checks if this instance can connect to the internet
+	 *
+	 * @return void
+	 *
+	 * @throws AppManagerException
+	 */
+	public function checkInternetConnection() {
+		$hasInternetConnection = $this->config->getSystemValue(
+			'has_internet_connection',
+			true
+		);
+		if ($hasInternetConnection !== true) {
+			throw new AppManagerException(
+				$this->l10n->t('The Internet connection is disabled.')
+			);
+		}
+	}
+
+	/**
+	 * @return string | null
+	 */
+	public function getApiKey() {
+		$configFileApiKey = $this->config->getSystemValue('marketplace.key', null);
+		if ($configFileApiKey) {
+			return $configFileApiKey;
+		}
+		return $this->config->getAppValue('market', 'key', null);
+	}
+
+	/**
+	 * @param string $path
+	 * @param array $options
+	 * @param string | null $apiKey
+	 *
+	 * @return \OCP\Http\Client\IResponse
+	 *
+	 * @throws AppManagerException
+	 */
+	private function httpGet($path, $options, $apiKey) {
+		if ($apiKey !== null) {
+			$options = array_merge(
+				[
+					'headers' => ['Authorization' => "apikey: $apiKey"]
+				],
+				$options
+			);
+		}
+		$ca = $this->config->getSystemValue('marketplace.ca', null);
+		if ($ca !== null) {
+			$options = array_merge(
+				[
+					'verify' => $ca
+				],
+				$options
+			);
+		}
+		$client = $this->httpClientService->newClient();
+		try {
+			$response = $client->get($path, $options);
+		} catch (TransferException $e) {
+			if ($e instanceof ClientException) {
+				if ($e->getCode() === 401) {
+					if ($apiKey !== null) {
+						throw new AppManagerException(
+							$this->l10n->t('Invalid marketplace API key provided')
+						);
+					}
+					throw new AppManagerException(
+						$this->l10n->t('Marketplace API key missing')
+					);
+				}
+				if ($e->getCode() === 402) {
+					throw new AppManagerException(
+						$this->l10n->t('Active subscription on marketplace required')
+					);
+				}
+			}
+			throw new AppManagerException(
+				$this->l10n->t(
+					'No marketplace connection: %s',
+					$e->getMessage()
+				),
+				0,
+				$e
+			);
+		}
+		return $response;
+	}
+
+	/**
+	 * @param string $code
+	 *
+	 * @return mixed
+	 *
+	 * @throws AppManagerException
+	 */
+	private function getEntities($code) {
+		$url = $this->urlConfig[$code];
+		if ($code === self::APPS) {
+			$ocVersion = $this->getPlatformVersion();
+			$versionArray = explode('.', $ocVersion);
+			$majorMinorPatchArray = array_slice($versionArray, 0, 3);
+			$platformVersion = implode('.', $majorMinorPatchArray);
+			$url = sprintf($url, $platformVersion);
+			$code = sprintf($code, $platformVersion);
+		} elseif ($code == self::DEMO_KEY) {
+			$instanceId = $this->config->getSystemValue('instanceid');
+			$url = sprintf($url, $instanceId);
+		}
+		return $this->queryData($code, $url);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPlatformVersion() {
+		$v = Util::getVersion();
+		return join('.', $v);
+	}
+
+	/**
+	 * @param string $relativeUrl
+	 * @return string
+	 */
+	private function getAbsoluteUrl($relativeUrl) {
+		$storeUrl = $this->config->getSystemValue('appstoreurl', 'https://marketplace.owncloud.com');
+		return rtrim($storeUrl, '/') . $relativeUrl;
+	}
+}

--- a/lib/HttpService.php
+++ b/lib/HttpService.php
@@ -28,7 +28,6 @@ use OCP\Http\Client\IClientService;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Util;
 
 /**
  * Class HttpService
@@ -52,6 +51,8 @@ class HttpService {
 
 	/** @var IClientService */
 	private $httpClientService;
+	/** @var VersionHelper */
+	private $versionHelper;
 	/** @var ICacheFactory */
 	private $cacheFactory;
 	/** @var IConfig */
@@ -69,11 +70,13 @@ class HttpService {
 	 */
 	public function __construct(
 		IClientService $httpClientService,
+		VersionHelper $versionHelper,
 		IConfig $config,
 		ICacheFactory $cacheFactory,
 		IL10N $l10n
 	) {
 		$this->httpClientService = $httpClientService;
+		$this->versionHelper = $versionHelper;
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
 		$this->l10n = $l10n;
@@ -280,10 +283,7 @@ class HttpService {
 	private function getEntities($code) {
 		$url = $this->urlConfig[$code];
 		if ($code === self::APPS) {
-			$ocVersion = $this->getPlatformVersion();
-			$versionArray = explode('.', $ocVersion);
-			$majorMinorPatchArray = array_slice($versionArray, 0, 3);
-			$platformVersion = implode('.', $majorMinorPatchArray);
+			$platformVersion = $this->versionHelper->getPlatformVersion(3);
 			$url = sprintf($url, $platformVersion);
 			$code = sprintf($code, $platformVersion);
 		} elseif ($code == self::DEMO_KEY) {
@@ -291,14 +291,6 @@ class HttpService {
 			$url = sprintf($url, $instanceId);
 		}
 		return $this->queryData($code, $url);
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getPlatformVersion() {
-		$v = Util::getVersion();
-		return join('.', $v);
 	}
 
 	/**

--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -33,12 +33,13 @@ class Listener {
 	}
 
 	public function upgradeAppStoreApp($app, $isMajorUpdate) {
-		$updateVersion = $this->marketService->getAvailableUpdateVersion(
-			$app,
+		$updateVersions = $this->marketService->getAvailableUpdateVersions($app);
+		$updateVersion = $this->marketService->chooseCandidate(
+			$updateVersions,
 			$isMajorUpdate
 		);
 		if ($updateVersion !== false) {
-			$this->marketService->updateApp($app, $isMajorUpdate);
+			$this->marketService->updateApp($app, $updateVersion);
 		} else {
 			throw new AppUpdateNotFoundException();
 		}

--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -32,10 +32,13 @@ class Listener {
 		$this->marketService = $marketService;
 	}
 
-	public function upgradeAppStoreApp($app){
-		$updateVersion = $this->marketService->getAvailableUpdateVersion($app);
+	public function upgradeAppStoreApp($app, $isMajorUpdate) {
+		$updateVersion = $this->marketService->getAvailableUpdateVersion(
+			$app,
+			$isMajorUpdate
+		);
 		if ($updateVersion !== false) {
-			$this->marketService->updateApp($app);
+			$this->marketService->updateApp($app, $isMajorUpdate);
 		} else {
 			throw new AppUpdateNotFoundException();
 		}

--- a/lib/VersionHelper.php
+++ b/lib/VersionHelper.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubinuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Market;
+
+use OCP\Util;
+
+/**
+ * Class VersionHelper
+ *
+ * @package OCA\Market
+ */
+class VersionHelper {
+	/**
+	 * Get the current ownCloud version
+	 *
+	 * @param int $cutTo
+	 *
+	 * @return string
+	 */
+	public function getPlatformVersion($cutTo = null) {
+		$v = Util::getVersion();
+		if ($cutTo !== null) {
+			$v = array_slice($v, 0, $cutTo);
+		}
+		return join('.', $v);
+	}
+
+	/**
+	 * Check if both versions has the same major part
+	 *
+	 * @param string $first
+	 * @param string $second
+	 *
+	 * @return bool
+	 */
+	public function isSameMajorVersion($first, $second) {
+		$firstMajor = $this->getMajorVersion($first);
+		$secondMajor = $this->getMajorVersion($second);
+		return $firstMajor === $secondMajor;
+	}
+
+	/**
+	 * @param string $first
+	 * @param string $second
+	 * @return mixed
+	 */
+	public function lessThanOrEqualTo($first, $second) {
+		return version_compare($first, $second, '<=');
+	}
+
+	/**
+	 * Parameters will be normalized and then passed into version_compare
+	 * in the same order they are specified in the method header
+	 *
+	 * @param string $first
+	 * @param string $second
+	 * @param string $operator
+	 *
+	 * @return bool result similar to version_compare
+	 */
+	public function compare($first, $second, $operator) {
+		// we can't normalize versions if one of the given parameters is not a
+		// version string but null. In case one parameter is null normalization
+		// will therefore be skipped
+		if ($first !== null && $second !== null) {
+			list($first, $second) = $this->normalizeVersions($first, $second);
+		}
+		return version_compare($first, $second, $operator);
+	}
+
+	/**
+	 * Truncates both versions to the lowest common version, e.g.
+	 * 5.1.2.3 and 5.1 will be turned into 5.1 and 5.1,
+	 * 5.2.6.5 and 5.1 will be turned into 5.2 and 5.1
+	 *
+	 * @param string $first
+	 * @param string $second
+	 *
+	 * @return string[] first element is the first version, second element is the
+	 * second version
+	 */
+	private function normalizeVersions($first, $second) {
+		$first = explode('.', $first);
+		$second = explode('.', $second);
+
+		// get both arrays to the same minimum size
+		$length = min(count($second), count($first));
+		$first = array_slice($first, 0, $length);
+		$second = array_slice($second, 0, $length);
+
+		return [implode('.', $first), implode('.', $second)];
+	}
+
+	/**
+	 * Get major version digits
+	 *
+	 * @param string $version
+	 *
+	 * @return int|null
+	 */
+	private function getMajorVersion($version) {
+		$versionArray = \explode('.', $version);
+		return isset($versionArray[0]) ? (int) $versionArray[0] : null;
+	}
+}

--- a/src/components/Details.vue
+++ b/src/components/Details.vue
@@ -82,9 +82,21 @@
 							| {{ t('uninstall') }}
 
 					// Update
-					div(v-if="updateable")
+					div(v-if="updateable && releases.length > 1").uk-button-group.uk-align-right.uk-margin-remove-bottom.uk-margin-small-left.uk-position-relative
+						button.uk-button.uk-button-primary._multiupdate-button(:disabled="processing", @click="update")
+							| {{ t('Update to') }} {{ releases[updateVersion].version }}
+						.uk-inline
+							button.uk-button.uk-button-primary._multiupdate-dropdown(:disabled="processing")
+								span(uk-icon='icon:  triangle-down')
+							div(uk-dropdown='mode: click; boundary: ! .uk-button-group; boundary-align: true; pos: top-center;')._multiupdate-uikit-element
+								ul.uk-nav.uk-dropdown-nav
+									li(v-for="(release, rid) in releases")
+										a(@click="setUpdateVersion(rid)") {{ t('version') }} {{ release.version }}
+
+					div(v-else-if="updateable && releases.length === 1")
 						button.uk-button.uk-button-primary.uk-align-right.uk-margin-remove-bottom.uk-margin-small-left.uk-position-relative(:disabled="processing", @click="update")
 							| {{ t('update') }}
+
 </template>
 <script>
 
@@ -96,6 +108,13 @@
 		mixins: [Mixins],
 		components: {
 			Rating
+		},
+		data () {
+			return {
+				// Key of releases array
+				// if length exeeds 1
+				updateVersion : 0
+			}
 		},
 		computed: {
 			loading() {
@@ -184,6 +203,10 @@
 			},
 			update () {
 				this.$store.dispatch('PROCESS_APPLICATION', [this.application.id, 'update'])
+			},
+			setUpdateVersion (version) {
+				UIkit.dropdown('._multiupdate-uikit-element').hide();
+				this.updateVersion = parseInt(version);
 			}
 		}
 	}
@@ -201,5 +224,14 @@
 
 	.uk-label {
 		font-size: .75rem;
+	}
+
+	._multiupdate-button {
+		padding-right: 5px;
+	}
+
+	._multiupdate-dropdown {
+		padding-left: 10px;
+		padding-right: 10px;
 	}
 </style>

--- a/src/components/Details.vue
+++ b/src/components/Details.vue
@@ -112,7 +112,7 @@
 		data () {
 			return {
 				// Key of releases array
-				// if length exeeds 1
+				// if length exceeds 1
 				updateVersion : 0
 			}
 		},
@@ -202,7 +202,11 @@
 				});
 			},
 			update () {
-				this.$store.dispatch('PROCESS_APPLICATION', [this.application.id, 'update'])
+				if (this.releases.length > 1) {
+					this.$store.dispatch('PROCESS_APPLICATION', [this.application.id, 'update', {'version' : this.releases[this.updateVersion].version}]);
+				} else {
+					this.$store.dispatch('PROCESS_APPLICATION', [this.application.id, 'update']);
+				}
 			},
 			setUpdateVersion (version) {
 				UIkit.dropdown('._multiupdate-uikit-element').hide();

--- a/src/components/Details.vue
+++ b/src/components/Details.vue
@@ -48,19 +48,17 @@
 
 				.uk-alert-primary(v-if="updateable && !processing && !loading", uk-alert)
 					a.uk-alert-close.uk-close
-					p
-						strong {{ t('Version %{version} available', {version: release.version}) }}&nbsp;
-						span {{ t('published on ') }} {{ release.created | formatDate }}.&nbsp;
+					div(v-for="update in releases")
+						strong {{ t('Version %{version} available', {version: update.version}) }}&nbsp;
+						span {{ t('published on ') }} {{ update.created | formatDate }}.&nbsp;
 						a(:href="application.marketplace", target="_blank") {{ t('Get more info') }}
-
-				div(v-if="updateable && !release.canInstall", uk-alert).uk-alert-danger
-					ul(v-if="!release.canInstall").uk-list
-						li(v-for="dependency in release.missingDependencies")
-							span(uk-icon="icon: warning; ratio: 0.75").uk-margin-small-right
-							| {{ dependency }}
-
-					p.uk-text-small
-						t.missingDep
+						.uk-alert.uk-alert-danger(v-if="!update.canInstall")
+							ul(v-if="!update.canInstall").uk-list
+								li(v-for="dependency in update.missingDependencies")
+									span(uk-icon="icon: warning; ratio: 0.75").uk-margin-small-right
+									| {{ dependency }}
+							p.uk-text-small
+								t.missingDep
 
 			.uk-card-footer
 				div(v-if="processing || loading")
@@ -135,8 +133,8 @@
 					return false
 				}
 				else {
-					if (this.application.release)
-						return this.application.release
+					if (this.application.releases)
+						return this.application.releases
 					return false
 				}
 			},
@@ -154,11 +152,15 @@
 				}
 			},
 
-			release () {
+			releases () {
 				if (!this.updateable)
 					return false;
-
-				return this.application.release;
+				return _.filter([
+					this.application.minorUpdate,
+					this.application.majorUpdate
+				], function (release) {
+					return release !== false;
+				});
 			}
 		},
 		filters: {

--- a/src/components/UpdateList.vue
+++ b/src/components/UpdateList.vue
@@ -54,7 +54,7 @@
 		},
 		methods: {
 			update (id, version) {
-				this.$store.dispatch('PROCESS_APPLICATION', [id, 'update'])
+				this.$store.dispatch('PROCESS_APPLICATION', [id, 'update', {'version' : version}])
 			},
 			processing(id) {
 				return _.contains(this.$store.state.processing, id)

--- a/src/components/UpdateList.vue
+++ b/src/components/UpdateList.vue
@@ -22,9 +22,15 @@
 								td
 									span {{ application.installInfo.version }}
 									span(uk-icon="icon: arrow-right").uk-margin-small-left.uk-margin-small-right
-									span {{ application.updateInfo }}
+									select(v-model="application.updateTo" v-if="application.minorUpdate !== false && application.majorUpdate !== false")
+										option(:value="application.minorUpdate.version" selected="selected") {{ application.minorUpdate.version }}
+										option(:value="application.majorUpdate.version") {{ application.majorUpdate.version }}
+									span(v-else-if="application.minorUpdate !== false") {{ application.minorUpdate.version }}
+										input(type="hidden" v-model="application.updateTo" value="application.minorUpdate.version")
+									span(v-else-if="application.majorUpdate !== false") {{ application.majorUpdate.version }}
+										input(type="hidden" v-model="application.updateTo" value="application.majorUpdate.version")
 								td
-									button.uk-button.uk-button-primary.uk-align-right.uk-margin-remove.uk-position-relative(@click="update(application.id)", :disabled="processing(application.id)")
+									button.uk-button.uk-button-primary.uk-align-right.uk-margin-remove.uk-position-relative(@click="update(application.id, application.updateTo)", :disabled="processing(application.id)")
 										span(v-if="processing(application.id)")
 											span.uk-position-small.uk-position-center-left(uk-spinner, uk-icon="icon: spinner; ratio: 0.8")
 											span.uk-margin-small-left &nbsp;&nbsp; {{ t('updating') }}
@@ -47,7 +53,7 @@
 			Tile
 		},
 		methods: {
-			update (id) {
+			update (id, version) {
 				this.$store.dispatch('PROCESS_APPLICATION', [id, 'update'])
 			},
 			processing(id) {

--- a/src/store.js
+++ b/src/store.js
@@ -236,8 +236,10 @@ const actions = {
 
         context.commit("START_PROCESSING", id);
 
+        let data = (options.version) ? {'toVersion' : options.version} : {};
+
         return Axios.post(OC.generateUrl("/apps/market/apps/{id}/" + route, {id}),
-            {}, {
+            data, {
                 headers: {
                     requesttoken: OC.requestToken
                 }

--- a/src/store.js
+++ b/src/store.js
@@ -89,7 +89,7 @@ const getters = {
 
     updateList: (state) => {
         return _.filter(state.applications.records, function (application) {
-            return application.updateInfo != false;
+            return application.updateInfo !== false;
         });
     },
 

--- a/tests/unit/CheckUpdateBackgroundJobTest.php
+++ b/tests/unit/CheckUpdateBackgroundJobTest.php
@@ -73,7 +73,7 @@ class CheckUpdateBackgroundJobTest extends TestCase{
 	public function dataCheckAppUpdate() {
 		return [
 			[
-				[ 'test'=> ['id' => 'test', 'version' => '1.2.4' ]],
+				[ 'test'=> ['id' => 'test', 'major' => false, 'minor' => '1.2.4' ]],
 				true,
 			],
 			[

--- a/tests/unit/HttpServiceTest.php
+++ b/tests/unit/HttpServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubinuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Market\Tests\Unit;
+
+use OCA\Market\HttpService;
+use OCP\App\AppManagerException;
+use OCP\Http\Client\IClientService;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IL10N;
+use Test\TestCase;
+
+/**
+ * Class HttpServiceTest
+ *
+ * @package OCA\Market\Tests\Unit
+ */
+class HttpServiceTest extends TestCase {
+	/** @var IClientService | \PHPUnit_Framework_MockObject_MockObject */
+	private $httpClientService;
+	/** @var ICacheFactory | \PHPUnit_Framework_MockObject_MockObject */
+	private $cacheFactory;
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	private $l10n;
+	/** @var HttpService */
+	private $httpService;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->httpClientService = $this->createMock(IClientService::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->httpService = new HttpService(
+			$this->httpClientService,
+			$this->config,
+			$this->cacheFactory,
+			$this->l10n
+		);
+	}
+
+	/**
+	 * @dataProvider testCheckInternetConnectionDataProvider
+	 */
+	public function textCheckInternetConnection($connectionStatus, $expectedExceptionClass) {
+		$this->config->method('getSystemValue')
+			->with(['has_internet_connection', true])
+			->willReturn($connectionStatus);
+		if ($expectedExceptionClass !== '') {
+			$this->expectException($expectedExceptionClass);
+		}
+	}
+
+	public function testCheckInternetConnectionDataProvider() {
+		return [
+			[true, ''],
+			[false, AppManagerException::class]
+		];
+	}
+}

--- a/tests/unit/HttpServiceTest.php
+++ b/tests/unit/HttpServiceTest.php
@@ -23,7 +23,9 @@ namespace OCA\Market\Tests\Unit;
 
 use OCA\Market\HttpService;
 use OCP\App\AppManagerException;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -77,5 +79,28 @@ class HttpServiceTest extends TestCase {
 			[true, ''],
 			[false, AppManagerException::class]
 		];
+	}
+
+	public function testGetApps() {
+		$expectedApps = [];
+		$this->config->expects($this->at(0))->method('getSystemValue')
+			->with('has_internet_connection', true)
+			->willReturn(true);
+		$this->config->expects($this->at(1))->method('getSystemValue')
+			->with('marketplace.key', null)
+			->willReturn('');
+
+		$clientMock = $this->getClientResponseMock(json_encode($expectedApps));
+		$this->httpClientService->method('newClient')->willReturn($clientMock);
+		$apps = $this->httpService->getApps();
+		$this->assertEquals($expectedApps, $apps);
+	}
+
+	private function getClientResponseMock($body) {
+		$responseMock = $this->createMock(IResponse::class);
+		$responseMock->method('getBody')->willReturn($body);
+		$clientMock = $this->createMock(IClient::class);
+		$clientMock->method('get')->willReturn($responseMock);
+		return $clientMock;
 	}
 }

--- a/tests/unit/HttpServiceTest.php
+++ b/tests/unit/HttpServiceTest.php
@@ -22,6 +22,7 @@
 namespace OCA\Market\Tests\Unit;
 
 use OCA\Market\HttpService;
+use OCA\Market\VersionHelper;
 use OCP\App\AppManagerException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
@@ -39,6 +40,8 @@ use Test\TestCase;
 class HttpServiceTest extends TestCase {
 	/** @var IClientService | \PHPUnit_Framework_MockObject_MockObject */
 	private $httpClientService;
+	/** @var VersionHelper | \PHPUnit_Framework_MockObject_MockObject */
+	private $versionHelper;
 	/** @var ICacheFactory | \PHPUnit_Framework_MockObject_MockObject */
 	private $cacheFactory;
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
@@ -51,11 +54,13 @@ class HttpServiceTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 		$this->httpClientService = $this->createMock(IClientService::class);
+		$this->versionHelper =  $this->createMock(VersionHelper::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->httpService = new HttpService(
 			$this->httpClientService,
+			$this->versionHelper,
 			$this->config,
 			$this->cacheFactory,
 			$this->l10n
@@ -65,13 +70,14 @@ class HttpServiceTest extends TestCase {
 	/**
 	 * @dataProvider testCheckInternetConnectionDataProvider
 	 */
-	public function textCheckInternetConnection($connectionStatus, $expectedExceptionClass) {
+	public function testCheckInternetConnection($connectionStatus, $expectedExceptionClass) {
 		$this->config->method('getSystemValue')
-			->with(['has_internet_connection', true])
+			->with('has_internet_connection', true)
 			->willReturn($connectionStatus);
 		if ($expectedExceptionClass !== '') {
 			$this->expectException($expectedExceptionClass);
 		}
+		$this->httpService->checkInternetConnection();
 	}
 
 	public function testCheckInternetConnectionDataProvider() {

--- a/tests/unit/MarketServiceTest.php
+++ b/tests/unit/MarketServiceTest.php
@@ -3,6 +3,7 @@
 namespace OCA\Market\Tests\Unit;
 
 use OCA\Market\HttpService;
+use OCA\Market\VersionHelper;
 use OCP\App\AppManagerException;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -17,22 +18,24 @@ class MarketServiceTest extends TestCase {
 	private $marketService;
 	/** @var HttpService | \PHPUnit_Framework_MockObject_MockObject $cacheFactoryMock */
 	private $httpService;
+	/** @var VersionHelper | \PHPUnit_Framework_MockObject_MockObject $cacheFactoryMock */
+	private $versionHelper;
 	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $appManager;
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $configMock */
 	private $config;
 
 	public function setUp() {
-		/** @var ICacheFactory | \PHPUnit_Framework_MockObject_MockObject $cacheFactoryMock */
 		$this->httpService = $this->createMock(HttpService::class);
+		$this->versionHelper = $this->createMock(VersionHelper::class);
 		$this->appManager = $this->createMock(IAppManager::class);
-		$this->appManager->method('getAllApps')->willReturn([]);
 		$this->config = $this->createMock(IConfig::class);
 		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10nMock */
 		$l10nMock = $this->createMock(IL10N::class);
 		$l10nMock->method('t')->willReturnArgument(0);
 		$this->marketService = new MarketService(
 			$this->httpService,
+			$this->versionHelper,
 			$this->appManager,
 			$this->config,
 			$l10nMock
@@ -43,6 +46,7 @@ class MarketServiceTest extends TestCase {
 	 * @expectedException \OCP\App\AppManagerException
 	*/
 	public function testInstallWithInternetConnectionDisabled(){
+		$this->appManager->method('getAllApps')->willReturn([]);
 		$this->appManager->method('canInstall')->willReturn(true);
 		$this->httpService->method('getApps')->willThrowException(
 			new AppManagerException()
@@ -54,6 +58,7 @@ class MarketServiceTest extends TestCase {
 	 * @expectedException \OCP\App\AppManagerException
 	*/
 	public function testUpdateWithInternetConnectionDisabled(){
+		$this->appManager->method('getAllApps')->willReturn([]);
 		$this->appManager->method('canInstall')->willReturn(true);
 		$this->marketService->updateApp('files');
 	}
@@ -64,6 +69,7 @@ class MarketServiceTest extends TestCase {
 	 * @expectedExceptionMessage Installing apps is not supported because the app folder is not writable.
 	 */
 	public function testInstallNotPossible($method) {
+		$this->appManager->method('getAllApps')->willReturn([]);
 		$this->appManager->method('canInstall')->willReturn(false);
 		$this->marketService->$method('test');
 	}
@@ -73,6 +79,7 @@ class MarketServiceTest extends TestCase {
 	 * @expectedExceptionMessage Please enter a license-key in to config.php
 	 */
 	public function testInstallAppChecksLicenseOnLatestRelease() {
+		$this->appManager->method('getAllApps')->willReturn([]);
 		$this->appManager->method('canInstall')->willReturn(true);
 		$this->httpService->method('getApps')->willReturn(
 			[
@@ -94,5 +101,157 @@ class MarketServiceTest extends TestCase {
 			['uninstallApp'],
 			['updateApp']
 		];
+	}
+
+	public function testUpdateToVersion() {
+		$appId = 'some_app';
+		$this->appManager->expects($this->any())
+			->method('canInstall')
+			->willReturn(true);
+		$this->appManager->expects($this->any())
+			->method('getAllApps')
+			->willReturn([$appId]);
+		$this->appManager->expects($this->any())
+			->method('getAppInfo')
+			->willReturn(
+					['id' => $appId, 'version' => '1.1']
+			);
+		$this->httpService->expects($this->any())
+			->method('getApps')
+			->willReturn(
+				[
+					[	'id' => $appId,
+						'releases' => [
+							[
+								'version' => '1.1',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+							[
+								'version' => '1.2.3',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'hit'
+							],
+							[
+								'version' => '1.3',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+						]
+					]
+				]
+			);
+		$this->httpService->expects($this->once())->method('downloadApp')
+			->with('hit', $this->anything());
+
+		$this->versionHelper->method('compare')->willReturn(false);
+		$this->marketService->updateApp('some_app', '1.2.3');
+	}
+
+	public function testRecentVersionIsInstalled() {
+		$appId = 'some_app';
+		$this->appManager->expects($this->any())
+			->method('canInstall')
+			->willReturn(true);
+		$this->appManager->expects($this->any())
+			->method('getAllApps')
+			->willReturn([]);
+		$this->appManager->expects($this->any())
+			->method('getAppInfo')
+			->willReturn([]);
+		$this->httpService->expects($this->any())
+			->method('getApps')
+			->willReturn(
+				[
+					[	'id' => $appId,
+						'releases' => [
+							[
+								'version' => '1.1',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+							[
+								'version' => '3.2.3',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'hit'
+							],
+							[
+								'version' => '2.3.0',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+						]
+					]
+				]
+			);
+		$this->httpService->expects($this->once())->method('downloadApp')
+			->with('hit', $this->anything());
+
+		$this->versionHelper->method('compare')->willReturn(false);
+		$this->marketService->installApp($appId);
+	}
+
+	public function testGetUpdateVersions() {
+		$versionHelper = new VersionHelper();
+		$appId = 'some_app';
+		$this->appManager->method('canInstall')
+			->willReturn(true);
+		$this->appManager->method('getAllApps')
+			->willReturn([$appId]);
+		$this->appManager->method('getAppInfo')
+			->willReturn(
+				['id' => $appId, 'version' => '1.1']
+			);
+		$this->httpService->method('getApps')
+			->willReturn(
+				[
+					[	'id' => $appId,
+						'releases' => [
+							[
+								'version' => '1.1',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+							[
+								'version' => '1.1.1',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+							[
+								'version' => '3.2.3',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'hit'
+							],
+							[
+								'version' => '2.3.0',
+								'license' => 'agpl',
+								'platformMin' => null,
+								'platformMax' => null,
+								'download' => 'miss'
+							],
+						]
+					]
+				]
+			);
+		$this->versionHelper->method('isSameMajorVersion')
+			->willReturnCallback([$versionHelper, 'isSameMajorVersion']);
+		$updatesAvailable = $this->marketService->getAvailableUpdateVersions($appId);
+		$this->assertEquals('1.1.1', $updatesAvailable['minor']);
+		$this->assertEquals('3.2.3', $updatesAvailable['major']);
 	}
 }

--- a/tests/unit/VersionHelperTest.php
+++ b/tests/unit/VersionHelperTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubinuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Market\Tests\Unit;
+
+use OCA\Market\VersionHelper;
+use Test\TestCase;
+
+class VersionHelperTest extends TestCase{
+	/** @var VersionHelper | \PHPUnit_Framework_MockObject_MockObject */
+	private $versionHelper;
+
+	protected function setUp() {
+		$this->versionHelper = new VersionHelper();
+	}
+	/**
+	 * @dataProvider dataTestIsSameMajorVersion
+	 *
+	 * @param string $first
+	 * @param string $second
+	 * @param bool $expected
+	 */
+	public function testIsSameMajorVersion($first, $second, $expected) {
+		$sameMajor = $this->versionHelper->isSameMajorVersion($first, $second);
+		$this->assertEquals($expected, $sameMajor);
+	}
+
+	public function dataTestIsSameMajorVersion() {
+		return [
+			['1.0', '1.1', true],
+			['1.0', '1.1', true],
+			['1.0', null, false],
+			['2.1.2', '1.2.3', false],
+			['5.1', '5.2.3', true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestCompare
+	 *
+	 * @param string $first
+	 * @param string $second
+	 * @param bool $expected
+	 */
+	public function testCompare($first, $second, $expected) {
+		$result = $this->versionHelper->compare($first, $second, '>');
+		$this->assertEquals($expected, $result);
+	}
+
+	public function dataTestCompare() {
+		return [
+			['1.0.2', '1.1', false],
+			['2.3.4', '1.1', true],
+			['1.0', null, true],
+			['2.1.2', '1.2.3.4', true],
+			['5.1', '5.2.3', false],
+		];
+	}
+}


### PR DESCRIPTION
### Summary
#### Core upgrade (this part depends on https://github.com/owncloud/core/pull/32491 that is still WIP)
- major (10 to 11 and like this) still DOES  upgrade apps  from 1.0 to 2.0 (if available)
- minor (10 to 10.1 and like this) does NOT apps upgrade from 1.0 to 2.0

#### CLI
- `market:upgrade` still DOES upgrade 1.0 to 1.1
- `market:upgrade` does NOT upgrade 1.0 to 2.0
- `market:upgrade --major` DOES upgrade 1.0 to 2.0
- `market:install` does NOT upgrade 1.0 to 2.0 if the app is already installed
- `market:install` still DOES upgrade 1.0 to 1.1 if the app is already installed

#### Market app Web UI
- Shows both 1.1 and 2.0 for 1.0, 1.1 is default

#### Market app cron job
- Generates notifications both for 1.1 and 2.0 

### Screenshots
#### Updates tab
![newupdatespage](https://user-images.githubusercontent.com/991300/48026770-08742080-e158-11e8-9cfc-e8c3ccdc0de2.png)

#### App Page
![apppage](https://user-images.githubusercontent.com/991300/48268486-26869d00-e446-11e8-98b9-46c58a2c4a36.png)


### TODO
- [x] add `--major` option  to CLI `market:upgrade` command
- [x] do not allow update to major releases with CLI `market:install` command
- [x] switch to major version of the app only in case there is a core major update is happening
    (Depends on https://github.com/owncloud/core/pull/32491)
- [x] Update app UI to show both minor and major updates
- [x] Allow update both to major and minor versions from UI


0.3.5 to 0.3.5
```
deo@jah-mobile:> php occ market:upgrade --local ../customgroups.tar.gz 
customgroups: ../customgroups.tar.gz has the same or older version of the app
```
0.3.5 to 1.3.5 (no `--major`)
```
deo@jah-mobile:> php occ market:upgrade --local ../customgroups.tar.gz 
customgroups: ../customgroups.tar.gz has a different major version, try with --major option
```

0.3.5 to 1.3.5 (with `--major`)
```
deo@jah-mobile:> php occ market:upgrade --local ../customgroups.tar.gz --major
customgroups: Installing new version from ../customgroups.tar.gz
```

###  after the merge
- [ ] Documentation needs to be updated