### PR TITLE
Fix failing upgrade app tests

### DIFF
--- a/tests/unit/Command/UpgradeAppTest.php
+++ b/tests/unit/Command/UpgradeAppTest.php
@@ -82,6 +82,7 @@ class UpgradeAppTest extends TestCase {
 				'minor' => false
 			]
 		);
+		$this->marketService->expects($this->once())->method('chooseCandidate')->willReturn(false);
 		$this->marketService->expects($this->never())->method('installApp');
 		$this->marketService->expects($this->never())->method('updateApp');
 		$this->commandTester->execute([
@@ -213,6 +214,9 @@ class UpgradeAppTest extends TestCase {
 				'major' => '2.0.0',
 				'minor' => false
 			]
+		);
+		$this->marketService->expects($this->once())->method('chooseCandidate')->willReturn(
+			false
 		);
 		$this->marketService->expects($this->once())->method('isAppInstalled')->willReturn(true);
 		$this->marketService->method('getInstalledAppInfo')


### PR DESCRIPTION
These methods return null without mocking so the  strict comparison against `false` fails.