### PR TITLE
Marketplace login

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,6 +23,7 @@ return [
 	'routes' => [
 		// ui controller
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+		['name' => 'page#indexHash', 'url' => '#/', 'verb' => 'GET'],
 		// market controller
 		['name' => 'market#categories', 'url' => '/categories', 'verb' => 'GET'],
 		['name' => 'market#bundles', 'url' => '/bundles', 'verb' => 'GET'],
@@ -36,7 +37,8 @@ return [
 		['name' => 'market#getConfig', 'url' => '/config', 'verb' => 'GET'],
 		['name' => 'market#requestDemoLicenseKeyFromMarket', 'url' => '/request-license-key-from-market', 'verb' => 'GET'],
 		['name' => 'market#invalidateCache', 'url' => '/cache/invalidate', 'verb' => 'POST'],
-		// local apps
+		['name' => 'market#receiveMarketplaceLoginToken', 'url' => '/check-marketplace-login-token', 'verb' => 'POST'],
+		['name' => 'market#startMarketplaceLogin', 'url' => '/generate-login-challenge', 'verb' => 'POST'],
 		['name' => 'localApps#index', 'url' => '/installed-apps/{state}', 'verb' => 'GET', 'defaults' => ['state' => 'enabled']],
 	],
 	'resources' => []

--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -351,7 +351,7 @@ class MarketController extends Controller {
 		$appStoreUrl = $this->config->getSystemValue('appstoreurl', 'https://marketplace.owncloud.com');
 
 		return new DataResponse([
-			'loginUrl' => "$appStoreUrl/api-login?callbackUrl=$callbackUrl&codeChallenge=$codeChallenge"
+			'loginUrl' => "$appStoreUrl/login?callbackUrl=$callbackUrl&codeChallenge=$codeChallenge"
 		]);
 	}
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -29,6 +29,17 @@ class PageController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
+	 *
+	 * Required for marketplace login to generate a callbackurl with
+	 * hash sign, or else login token will be attached before it resulting
+	 * in a broken url.
+	 */
+	public function indexHash() {
+		return $this->index();
+	}
+
+	/**
+	 * @NoCSRFRequired
 	 */
 	public function index() {
 		$templateResponse = new TemplateResponse($this->appName, 'index', []);

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
                     p {{ t("This is a clustered setup or the web server has no permissions to write to the apps folder.") }}
             aside.uk-width-auto
                 navigation
+                login
                 trial
             main.uk-width-expand
                 router-view
@@ -17,6 +18,7 @@
     import Mixins from './mixins.js'
     import Navigation from './components/Navigation.vue'
     import Trial from './components/Trial.vue'
+	import Login from './components/Login.vue'
 
     export default {
         mixins: [Mixins],
@@ -49,7 +51,8 @@
         methods: { },
         components: {
             Navigation,
-            Trial
+			Login,
+			Trial
         }
     }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,68 +1,68 @@
 <template lang="pug">
-    .uk-padding(v-if="config")
-        .uk-grid-large(uk-grid)
-            .uk-width-1-1(v-if="showNotice").uk-animation-slide-top-small
-                .uk-alert-primary(uk-alert)
-                    span.uk-alert-close(uk-close, @click.prevent="noticeDismissed = true")
-                    h1.uk-h5 {{ t("Installing and updating Apps is not supported!") }}
-                    p {{ t("This is a clustered setup or the web server has no permissions to write to the apps folder.") }}
-            aside.uk-width-auto
-                navigation
-                login
-                trial
-            main.uk-width-expand
-                router-view
+	.uk-padding(v-if="config")
+		.uk-grid-large(uk-grid)
+			.uk-width-1-1(v-if="showNotice").uk-animation-slide-top-small
+				.uk-alert-primary(uk-alert)
+					span.uk-alert-close(uk-close, @click.prevent="noticeDismissed = true")
+					h1.uk-h5 {{ t("Installing and updating Apps is not supported!") }}
+					p {{ t("This is a clustered setup or the web server has no permissions to write to the apps folder.") }}
+			aside.uk-width-auto
+				navigation
+				login
+				trial
+			main.uk-width-expand
+				router-view
 </template>
 
 <script>
-    import Mixins from './mixins.js'
-    import Navigation from './components/Navigation.vue'
-    import Trial from './components/Trial.vue'
+	import Mixins from './mixins.js'
+	import Navigation from './components/Navigation.vue'
+	import Trial from './components/Trial.vue'
 	import Login from './components/Login.vue'
 
-    export default {
-        mixins: [Mixins],
-        data () {
-            return {
-                "noticeDismissed" : false
-            }
-        },
-        mounted () {
-            this.$store.dispatch('FETCH_CONFIG');
-            this.$store.dispatch('FETCH_APPLICATIONS');
+	export default {
+		mixins: [Mixins],
+		data () {
+			return {
+				"noticeDismissed" : false
+			}
+		},
+		mounted () {
+			this.$store.dispatch('FETCH_CONFIG');
+			this.$store.dispatch('FETCH_APPLICATIONS');
 
 			this.$store.watch(
-			    (state)  => {
+				(state)  => {
 					return state.installed;
-			    },
-			    () => {
+				},
+				() => {
 					this.$store.dispatch('REBUILD_NAVIGATION');
-			    }
+				}
 			);
-        },
-        computed: {
-            config () {
-                return this.$store.getters.config
-            },
-            showNotice() {
-                return this.noticeDismissed === false && this.config.canInstall === false
-            }
-        },
-        methods: { },
-        components: {
-            Navigation,
+		},
+		computed: {
+			config () {
+				return this.$store.getters.config
+			},
+			showNotice() {
+				return this.noticeDismissed === false && this.config.canInstall === false
+			}
+		},
+		methods: { },
+		components: {
+			Navigation,
 			Login,
 			Trial
-        }
-    }
+		}
+	}
 </script>
 
 <style lang="scss" scoped>
-    #market-app {
-        min-height: 100%;
-    }
+	#market-app {
+		min-height: 100%;
+	}
 
-    aside {
-        width: 300px;
-    }
+	aside {
+		width: 300px;
+	}
 </style>

--- a/src/components/ApiForm.vue
+++ b/src/components/ApiForm.vue
@@ -43,7 +43,6 @@
 				UIkit.modal('#view-api-key').toggle();
 			},
 			setKey () {
-				console.log("setKey");
 				this.$store.dispatch('WRITE_APIKEY', this.newKey);
 			}
 		},

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,0 +1,76 @@
+<template lang="pug">
+	div
+		button.uk-button.uk-button-primary.uk-margin-small-top.uk-width-1-1(v-if="!isLoggedIn", @click="startMarketplaceLogin") {{ t('Login') }}
+
+</template>
+
+<script>
+
+	import Mixins from '../mixins';
+	import Axios from 'axios';
+	import _ from 'underscore';
+
+	export default {
+		mixins: [Mixins],
+		data () {
+			return {
+				token: null,
+				isLoggedIn: null
+			}
+		},
+		created() {
+
+		},
+		mounted() {
+			if (!this.$route.query.hasOwnProperty('token')) {
+				return
+			}
+
+			let token = this.$route.query.token;
+
+			Axios.post(OC.generateUrl('/apps/market/check-marketplace-login-token'), {token: token})
+				.then((response) => {
+					return this.$store.dispatch('WRITE_APIKEY', response.data.apiKey)
+				})
+				.catch((error) => {
+					console.log(error)
+				});
+
+		},
+		methods : {
+			startMarketplaceLogin () {
+				Axios.post(OC.generateUrl('/apps/market/generate-login-challenge'))
+					.then((response) => {
+						window.location = response.data.loginUrl
+					})
+					.catch((error) => {
+						console.log(error)
+					});
+			},
+		},
+		computed : {
+			config() {
+				return this.$store.getters.config
+			},
+
+			apiKeyExists () {
+				if (this.$store.state.apikey.key) {
+					return this.$store.state.apikey.key.length > 0;
+				}
+
+				return false;
+			},
+		}
+	}
+</script>
+
+<style lang="css" scoped>
+	.-monospace {
+		font-family: "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", monospace;
+	}
+
+	.intro {
+		font-size: 14px;
+		line-height: 24px;
+	}
+</style>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,11 +1,10 @@
 <template lang="pug">
 	div
-		button.uk-button.uk-button-primary.uk-margin-small-top.uk-width-1-1(v-if="!isLoggedIn", @click="startMarketplaceLogin") {{ t('Login') }}
-
+		button.uk-button.uk-button-primary.uk-margin-small-top.uk-width-1-1(:disabled="apiKeyIsValid", @click="startMarketplaceLogin")
+			span(v-if="!apiKeyIsValid") {{ t('Login') }}
+			span(v-else) {{ t('Loggen in') }}
 </template>
-
 <script>
-
 	import Mixins from '../mixins';
 	import Axios from 'axios';
 	import _ from 'underscore';
@@ -22,6 +21,10 @@
 
 		},
 		mounted() {
+			this.$store.dispatch('FETCH_APIKEY', (response) => {
+				this.$store.dispatch('WRITE_APIKEY', response.apiKey);
+			});
+			
 			if (!this.$route.query.hasOwnProperty('token')) {
 				return
 			}
@@ -51,6 +54,10 @@
 		computed : {
 			config() {
 				return this.$store.getters.config
+			},
+
+			apiKeyIsValid () {
+				return this.$store.state.apikey.valid;
 			},
 
 			apiKeyExists () {

--- a/src/store.js
+++ b/src/store.js
@@ -361,7 +361,7 @@ const actions = {
             });
     },
 
-    FETCH_APIKEY (context) {
+    FETCH_APIKEY (context, callback) {
         context.commit("APIKEY", {"loading": true });
         Axios.get(OC.generateUrl("/apps/market/apikey"))
             .then((response) => {
@@ -370,10 +370,16 @@ const actions = {
                     "changeable" : response.data.changeable,
                     "loading"    : false,
                     "processing" : false
-                });
+				});
+				
+				if (typeof callback === 'function')
+					callback(response.data);
             })
             .catch((error) => {
-                context.commit("APIKEY", {"loading": false });
+				context.commit("APIKEY", {"loading": false });
+				
+				if (typeof callback === 'function')
+					callback(error);
             });
     },
 

--- a/tests/unit/PageControllerTest.php
+++ b/tests/unit/PageControllerTest.php
@@ -31,4 +31,16 @@ class PageControllerTest extends TestCase {
 
 		$this->assertEquals('index', $response->getTemplateName());
 	}
+
+	public function testIndexHash() {
+		$response = $this->controller->indexHash();
+
+		$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$policy->addAllowedImageDomain('https://storage.marketplace.owncloud.com');
+		$policy->addAllowedImageDomain('https://marketplace-storage.int.owncloud.com');
+		$policy->addAllowedImageDomain('http://minio:9000');
+		$this->assertEquals($policy, $response->getContentSecurityPolicy());
+
+		$this->assertEquals('index', $response->getTemplateName());
+	}
 }


### PR DESCRIPTION
Login directly from market-app to auto-install your api-key. 

- Market app send its callback-url and [PKCE](https://tools.ietf.org/html/rfc7636)-Challenge to marketplace.
- A marketplace login and approval prompt is presented to the user.
- If user approves prompt, a one-time token is generated and forwarded to the market app.
- The Token is used together with PKCE-Verify-code by market app to retrieve the api-key.

This PR can be tested against staging marketplace by setting appstoreurl.

This is *NOT* OAuth because OAuth requires a static callback-url

Closes #425 