### PR TITLE
add a note to explain where to get api key

### DIFF
--- a/src/components/Trial.vue
+++ b/src/components/Trial.vue
@@ -12,8 +12,10 @@
 						p.intro Take your ownCloud to the next level and start your 30 day ownCloud Enterprise Trial today!
 
 						.uk-alert-danger(uk-alert, v-if="!apiKeyExists")
-							p An Marketplace API key is required!&nbsp;
-								a(href="#", @click.prevent="openModalEditKey") Set API key here
+							p A Marketplace API key is required! Please copy it from&nbsp;
+								a(href="https://marketplace.owncloud.com/account/general") your profile page on the Marketplace
+								| . Then&nbsp;
+								a(href="#", @click.prevent="openModalEditKey") enter the API key here
 								| &nbsp;and try again.
 
 						.uk-margin.uk-grid-small.uk-child-width-auto(uk-grid)


### PR DESCRIPTION
resolves #463 
PR adds a text to start-enterprise-trial modal that explains where a user can get an API key. 

@dercorn I made several grep searches in the repo and I found the message "API key missing" only here. I hope it is the place that you suggested to add an explanation.

## Screenshot
![image](https://user-images.githubusercontent.com/14157973/56117364-95759e00-5f70-11e9-9600-1bc228b373c0.png)
