### PR TITLE
Add php unit composer dependencies to Makefile

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1130,6 +1130,7 @@ def installCore(version, db, useBundledApp):
 		'settings': {
 			'version': version,
 			'core_path': '/var/www/owncloud/server',
+			'db_timeout': 120,
 			'db_type': dbType,
 			'db_name': database,
 			'db_host': host,

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,6 +124,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/market
@@ -190,6 +191,7 @@ steps:
     db_host: mariadb
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market
@@ -266,6 +268,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market
@@ -342,6 +345,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market
@@ -418,6 +422,7 @@ steps:
     db_host: postgres
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: pgsql
     db_username: owncloud
     exclude: apps/market
@@ -493,6 +498,7 @@ steps:
     db_host: oracle
     db_name: XE
     db_password: oracle
+    db_timeout: 120
     db_type: oci
     db_username: system
     exclude: apps/market
@@ -569,6 +575,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market
@@ -636,6 +643,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market
@@ -703,6 +711,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/market

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,12 @@ clean-build:
 
 .PHONY: test-php-unit
 test-php-unit: ## Run php unit tests
-test-php-unit:
+test-php-unit: $(composer_deps)
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg: ## Run php unit tests using phpdbg
-test-php-unit-dbg:
+test-php-unit-dbg: $(composer_deps)
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style


### PR DESCRIPTION
## Description
If I clone this repo and immediately `make test-php-unit` it dies. I first need to know to do `composer install` or some other `make` target that will install the composer dependencies.

Add the composer dependencies so that `make test-php-unit` will "just work"

(I noticed this when sorting out `Makefile` for the metrics app)

## How Has This Been Tested?
Local `make test-php-unit`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] tests only

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

