### PR TITLE
Clean vendor-bin from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ $(composer_deps): composer.json composer.lock
 .PHONY: clean-composer-deps
 clean-composer-deps:
 	rm -Rf $(composer_deps)
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 .PHONY: update-composer
 update-composer:


### PR DESCRIPTION
So developers can `make clean` properly.