### PR TITLE
Fix version_compare calls

### DIFF
--- a/lib/Controller/MarketController.php
+++ b/lib/Controller/MarketController.php
@@ -284,7 +284,7 @@ class MarketController extends Controller {
 			\usort(
 				$releases,
 				function ($a, $b) {
-					return \version_compare($a['version'], $b['version'], '>');
+					return \version_compare($a['version'], $b['version']);
 				}
 			);
 			if (!empty($releases)) {

--- a/lib/MarketService.php
+++ b/lib/MarketService.php
@@ -574,7 +574,7 @@ class MarketService {
 		);
 		\usort(
 			$releases, function ($a, $b) {
-				return \version_compare($a['version'], $b['version'], '>');
+				return \version_compare($a['version'], $b['version']);
 			}
 		);
 		if (!empty($releases)) {


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/market/1830/4/4
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ ---------------------------------------------------------------------- 
  Line   lib/Controller/MarketController.php                                   
 ------ ---------------------------------------------------------------------- 
  286    Parameter #2 $cmp_function of function usort expects callable(mixed,  
         mixed): int, Closure(mixed, mixed): bool given.                       
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   lib/MarketService.php                                                 
 ------ ---------------------------------------------------------------------- 
  576    Parameter #2 $cmp_function of function usort expects callable(mixed,  
         mixed): int, Closure(mixed, mixed): bool given.                       
 ------ ---------------------------------------------------------------------- 

 [ERROR] Found 2 errors                                                         
```

The latest version of `phpstan` has detected this existing problem.

```
return \version_compare($a['version'], $b['version'], '>');
```

That call with the `>` parameter returns a boolean. But the surrounding `usort` actually expects an `int` to be return (-1, 0, or 1).