### PR TITLE
Use relative url instead of absoulute url

### DIFF
--- a/lib/CheckUpdateBackgroundJob.php
+++ b/lib/CheckUpdateBackgroundJob.php
@@ -85,7 +85,7 @@ class CheckUpdateBackgroundJob extends TimedJob {
 		$updates = $this->marketService->getUpdates();
 
 		foreach ($updates as $appId => $appInfo) {
-			$url = $this->urlGenerator->linkToRouteAbsolute(
+			$url = $this->urlGenerator->linkToRoute(
 				'market.page.index'
 			);
 			$url .= '#/app/' . $appId;

--- a/tests/unit/CheckUpdateBackgroundJobTest.php
+++ b/tests/unit/CheckUpdateBackgroundJobTest.php
@@ -104,7 +104,7 @@ class CheckUpdateBackgroundJobTest extends TestCase {
 
 		if ($shouldNotify) {
 			$this->urlGenerator->expects($this->once())
-				->method('linkToRouteAbsolute')
+				->method('linkToRoute')
 				->with('market.page.index')
 				->willReturn('meow');
 
@@ -113,7 +113,7 @@ class CheckUpdateBackgroundJobTest extends TestCase {
 				->willReturn(null);
 		} else {
 			$this->urlGenerator->expects($this->never())
-				->method('linkToRouteAbsolute');
+				->method('linkToRoute');
 
 			$job->expects($this->never())
 				->method('createNotifications');


### PR DESCRIPTION
Related to https://github.com/owncloud/enterprise/issues/4250 as notifications URLs shouldn't be absolute to prevent problems with CORS.