### PR TITLE
[tests-only] [full-ci] Remove npm checks from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,7 @@
 SHELL := /bin/bash
 
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
-
-#
-# Define NPM and check if it is available on the system.
-#
 NPM := $(shell command -v npm 2> /dev/null)
-ifndef NPM
-    $(error npm is not available on your system, please install npm)
-endif
 
 app_name=$(notdir $(CURDIR))
 project_directory=$(CURDIR)/../$(app_name)


### PR DESCRIPTION
The `owncloudci/php` image no longer has nodejs, npm or yarn. It runs PHP tests fine, and we should not complain that `npm` is missing.

Remove the annoying checks from `Makefile`