### PR TITLE
Fix issues when the market API key is an empty string

### DIFF
--- a/lib/HttpService.php
+++ b/lib/HttpService.php
@@ -245,7 +245,7 @@ class HttpService {
 	 * @throws AppManagerException
 	 */
 	private function httpGet($path, $options, $apiKey) {
-		if ($apiKey !== null) {
+		if (!empty($apiKey)) {
 			$options = \array_merge(
 				[
 					'headers' => ['Authorization' => "apikey: $apiKey"]


### PR DESCRIPTION
Due to https://github.com/owncloud/core/pull/39554, `null` will be transformed to an empty string when retrieving values from the `oc_appconfig` table. This makes the market app unusable in this scenario, so we need to omit the API key if empty.

Related to https://github.com/owncloud/core/issues/39616