### PR TITLE
Bump owncloud min-version to 10.11 for Guzzle7

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ To use this application click on "Files" in the top left corner and click on "Ma
 	<category>tools</category>
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/market/ownCloud-market-app.jpg</screenshot>
 	<dependencies>
-		<owncloud min-version="10.5" max-version="10" />
+		<owncloud min-version="10.11" max-version="10" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Market\CheckUpdateBackgroundJob</job>


### PR DESCRIPTION
needed after #817 was merged. That added Guzzle7.