### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/InstallApp.php
+++ b/lib/Command/InstallApp.php
@@ -66,10 +66,10 @@ class InstallApp extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|null
+	 * @return int
 	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->marketService->canInstall()) {
 			throw new \Exception("Installing apps is not supported because the app folder is not writable.");
 		}

--- a/lib/Command/ListApps.php
+++ b/lib/Command/ListApps.php
@@ -23,7 +23,6 @@ namespace OCA\Market\Command;
 
 use OCA\Market\MarketService;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -41,7 +40,7 @@ class ListApps extends Command {
 			->setDescription('Lists apps as available on the marketplace.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$apps = $this->marketService->listApps();
 		} catch (\Exception $ex) {

--- a/lib/Command/UnInstallApp.php
+++ b/lib/Command/UnInstallApp.php
@@ -51,7 +51,7 @@ class UnInstallApp extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->marketService->canInstall()) {
 			throw new \Exception("Un-Installing apps is not supported because the app folder is not writable.");
 		}

--- a/lib/Command/UpgradeApp.php
+++ b/lib/Command/UpgradeApp.php
@@ -79,7 +79,7 @@ class UpgradeApp extends Command {
 	 *
 	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->marketService->canInstall()) {
 			throw new \Exception("Installing apps is not supported because the app folder is not writable.");
 		}

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630