### PR TITLE
Update Makefile to fix make dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ all: $(js_deps) js/market.bundle.js
 
 .PHONY: clean
 clean: clean-composer-deps clean-js-deps clean-dist clean-build
-	rm js/market.bundle.js
+	rm -f js/market.bundle.js
 
 #
 # ownCloud market PHP dependencies


### PR DESCRIPTION
@DeepDiver1975 your
rm js/market.bundle.js
fails in the nightly builds:
```
rm js/market.bundle.js
rm: cannot remove 'js/market.bundle.js': No such file or directory make: *** [Makefile:53: clean] Error 1
```
I am introducing a -f here to make it pass, but please double check, if this hides a logic error somewhere else...