### PR TITLE
Revert "chore(deps): bump vue-template-compiler from 2.5.21 to 2.7.16"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vue-pug-loader": "^1.1.29",
         "vue-router": "3.5.2",
         "vue-style-loader": "^4.1.3",
-        "vue-template-compiler": "2.7.16",
+        "vue-template-compiler": "2.5.21",
         "vuex": "3.6.2",
         "webpack": "^5.105.0"
       },
@@ -7330,13 +7330,13 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+      "version": "2.5.21",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.21.tgz",
+      "integrity": "sha512-Vmk5Cv7UcmI99B9nXJEkaK262IQNnHp5rJYo+EwYpe2epTAXqcVyExhV6pk8jTkxQK2vRc8v8KmZBAwdmUZvvw==",
       "license": "MIT",
       "dependencies": {
         "de-indent": "^1.0.2",
-        "he": "^1.2.0"
+        "he": "^1.1.0"
       }
     },
     "node_modules/vue-template-es2015-compiler": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vue-pug-loader": "^1.1.29",
     "vue-router": "3.5.2",
     "vue-style-loader": "^4.1.3",
-    "vue-template-compiler": "2.7.16",
+    "vue-template-compiler": "2.5.21",
     "vuex": "3.6.2",
     "webpack": "^5.105.0"
   },


### PR DESCRIPTION
Reverts owncloud/market#1362

vue-template-compiler has to stay on 2.5.12 just like vue-js itself