### PR TITLE
chore(deps): specify at least PHP 8.3 in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
   "name": "owncloud/market",
   "config" : {
     "platform": {
-        "php": "7.3"
+        "php": "8.3"
     },
     "allow-plugins": {
       "bamarni/composer-bin-plugin": true
     }
   },
   "require": {
-      "php": ">=7.3"
+      "php": ">=8.3"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.8"

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
   "name": "owncloud/market",
   "config" : {
     "platform": {
-        "php": "7.3"
+        "php": "8.3"
     },
     "allow-plugins": {
       "bamarni/composer-bin-plugin": true
     }
   },
   "require": {
-      "php": ">=7.3"
+      "php": ">=8.3"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45939701975cf8ec8b421e1288bf2a2c",
+    "content-hash": "0ef4f5e9b603744efcdb16e2f8ee2f23",
     "packages": [],
     "packages-dev": [
         {
@@ -71,11 +71,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.3"
+        "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "925941b9886aa0109597b5fc9c7116dc",
+    "content-hash": "04347d752593aa41356e7c80eda69b2b",
     "packages": [],
     "packages-dev": [
         {
@@ -71,11 +71,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.3"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
https://github.com/owncloud/market/blob/master/appinfo/info.xml already has `php min-version="8.3"`

We may as well specify this in `composer.json` also.

It doesn't make much difference, because the market app doesn't have any important dependencies in `composer.json` anyway.