### PR TITLE
fix: disable terser parallelism to stop webpack build hanging in CI

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
 	mode: 'production',
@@ -7,6 +8,15 @@ module.exports = {
 		path: require('path').resolve(__dirname, 'js'),
 		filename : 'market.bundle.js',
 		publicPath: '/'
+	},
+	optimization: {
+		// Disable terser's parallel worker pool: in CI the jest-worker child
+		// processes can fail to terminate, leaving webpack hanging after the
+		// build completes until the job hits the 6h timeout. Building
+		// single-threaded is negligibly slower for this bundle.
+		minimizer: [
+			new TerserPlugin({ parallel: false })
+		]
 	},
 	module: {
 		rules: [{


### PR DESCRIPTION
## Problem

The **Build dist** job (`make dist` → `npm run build` → `NODE_ENV=production webpack`) never completes in CI. webpack reports the bundle as compiled, but the process does not terminate, so the job runs until GitHub's 6-hour ceiling and is cancelled.

This is **pre-existing and environment-wide** — across the last 30 "Build dist" runs there are **0 successes** (26 cancelled at the 6h timeout, 4 failures), affecting `master`, dependabot branches, and PRs alike. The reusable build workflow has no step timeout, so any hang runs the full 6h.

## Root cause

Webpack 5's default minimizer is `terser-webpack-plugin` with `parallel: true`, which spawns a `jest-worker` child-process pool. Those workers can fail to shut down on the CI runner, keeping the Node process alive after "compiled successfully" — exactly the observed symptom (webpack not terminating).

## Fix

Set `optimization.minimizer` to a single `TerserPlugin({ parallel: false })`. Disabling the worker pool makes the process exit deterministically. Minification still runs; the build is only negligibly slower for a bundle this size (~15s locally).

## Verification

- Built the edited config locally: produces a valid `js/market.bundle.js` (~1.1 MB) and the process **exits cleanly with no lingering `webpack`/`jest-worker` processes**.
- Note: the hang does not reproduce on a local multi-core dev machine — it is specific to the CI runner — so this is verified by confirming the fixed build compiles and terminates cleanly. Final confirmation is the green "Build dist" check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)