### PR TITLE
fix: show app version in details for non-installed apps

### DIFF
--- a/src/components/Details.vue
+++ b/src/components/Details.vue
@@ -152,8 +152,8 @@
 					return false
 				}
 				else {
-					if (this.application.releases)
-						return this.application.releases
+					if (this.application.release)
+						return this.application.release
 					return false
 				}
 			},


### PR DESCRIPTION
## Summary

The app details view rendered an empty version (and creation date) for apps that are **not installed**.

The `details()` computed property referenced `this.application.releases` (plural), which does not exist on the application object — so `details.version` and `details.created` in the template resolved to nothing.

This changes it to `this.application.release` (singular), matching what `license()` and `installable()` already use for non-installed apps.

## Test plan

- Open the details page of an app that is **not** installed
- Confirm the version number now appears in the details table

🤖 Generated with [Claude Code](https://claude.com/claude-code)