### PR TITLE
fix: exit webpack build process so CI "Build dist" terminates

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,29 @@
+// Programmatic webpack build runner.
+//
+// Why this exists instead of calling the `webpack` CLI directly:
+// vue-template-compiler (pulled in by vue-loader) runs Vue 2's nextTick setup
+// at require() time, which creates a native MessageChannel and registers
+// `channel.port1.onmessage`. On Node >=12 that ref'd MessagePort keeps the
+// event loop alive indefinitely, so the process never exits after the bundle
+// has compiled. In CI the "Build dist" job then runs until the 6h ceiling and
+// is cancelled. Running webpack programmatically lets us call process.exit()
+// once the build is done, so the lingering handle can no longer block exit.
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+const webpack = require('webpack');
+const config = require('./webpack.config.js');
+
+webpack(config).run((err, stats) => {
+	if (err) {
+		console.error(err.stack || err);
+		if (err.details) {
+			console.error(err.details);
+		}
+		process.exit(1);
+	}
+
+	console.log(stats.toString({ colors: true }));
+
+	process.exit(stats.hasErrors() ? 1 : 0);
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack  --progress --colors --watch",
     "build-dev": "webpack",
-    "build": "NODE_ENV=production webpack"
+    "build": "NODE_ENV=production node build.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The **Build dist** job (`make dist` → `npm run build` → `NODE_ENV=production webpack`) never completes in CI. webpack reports the bundle as compiled in ~15s, but the process does not terminate, so the job runs until GitHub's 6-hour ceiling and is cancelled — affecting `master`, dependabot branches, and PRs alike.

## Root cause

`vue-loader` pulls in `vue-template-compiler`, which at `require()` time runs Vue 2's `nextTick` setup. That code creates a native `MessageChannel` and registers `channel.port1.onmessage = flushCallbacks` (see `vue-template-compiler/build.js`). On Node ≥12 the ref'd `MessagePort` keeps the event loop alive **indefinitely**, so the webpack CLI — which simply waits for the loop to drain — never exits after compilation.

This reproduces locally as well: after the build completes, `process._getActiveHandles()` shows two lingering `MessagePort` handles. The hang is **independent of minification** — it reproduces with terser disabled entirely — so the minimizer was never involved. (This supersedes the earlier terser-parallelism theory in #1434, whose own `build / Build` check still failed at the 6h timeout.)

## Fix

Run webpack via a small `build.js` runner that calls `process.exit()` once the build finishes, so the lingering `MessagePort` can no longer block exit. `package.json`'s `build` script now points at it.

## Verification

- `npm run build` exits **cleanly (code 0) in ~16s** with a valid `js/market.bundle.js` (~1.1 MB) and **no lingering `node`/`webpack` processes**.
- Final confirmation is a green **Build dist** check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
