### PR TITLE
release: market 0.9.1 (oc10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.9.1] - 2026-07-17
+
+### Changed
+
+- [#1433](https://github.com/owncloud/market/pull/1433) - feat: allow configured appstoreurl as CSP image domain
+
+
 ## [0.9.0] - 2024-06-04
 
 - [#1292](https://github.com/owncloud/market/pull/1292) - fix: use webpack 5
@@ -195,7 +202,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Skip migrations when reinstalling missing code - [#76](https://github.com/owncloud/market/issues/76)
 - Reset overwritten core css styles - [#73](https://github.com/owncloud/market/issues/73)
 
-[Unreleased]: https://github.com/owncloud/market/compare/v0.9.0...master
+[0.9.1]: https://github.com/owncloud/market/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/owncloud/market/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/owncloud/market/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/owncloud/market/compare/v0.6.3...v0.7.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Please note: Since ownCloud X (10.0) every instance gets shipped with this app i
 To use this application click on "Files" in the top left corner and click on "Market" (cart icon) (Administrator privileges required) </description>
 	<licence>AGPL</licence>
 	<author>Thomas Müller, Felix Heidecke, Thomas Börger, Philipp Schaffrath, Viktar Dubiniuk</author>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 	<default_enable/>
 	<category>tools</category>
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/market/ownCloud-market-app.jpg</screenshot>

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -25,8 +25,18 @@ namespace OCA\Market\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IRequest;
 
 class PageController extends Controller {
+	/** @var IConfig */
+	private $config;
+
+	public function __construct($appName, IRequest $request, IConfig $config) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+	}
+
 	/**
 	 * @NoCSRFRequired
 	 *
@@ -50,8 +60,32 @@ class PageController extends Controller {
 		$policy->addAllowedImageDomain('https://marketplace-storage.staging.owncloud.services');
 		// local dev storage
 		$policy->addAllowedImageDomain('http://minio:9000');
+		// configured appstore (may serve its own images)
+		$storeUrl = $this->config->getSystemValue('appstoreurl', 'https://marketplace.owncloud.com');
+		$storeDomain = $this->extractDomain($storeUrl);
+		if ($storeDomain !== null) {
+			$policy->addAllowedImageDomain($storeDomain);
+		}
 		$templateResponse->setContentSecurityPolicy($policy);
 
 		return $templateResponse;
+	}
+
+	/**
+	 * Reduce a URL to scheme + host (+ port) since CSP works on the domain
+	 * level - any path in the configured appstore URL must be stripped.
+	 *
+	 * @return string|null the domain, or null if it cannot be determined
+	 */
+	private function extractDomain(string $url): ?string {
+		$parts = \parse_url($url);
+		if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+			return null;
+		}
+		$domain = $parts['scheme'] . '://' . $parts['host'];
+		if (isset($parts['port'])) {
+			$domain .= ':' . $parts['port'];
+		}
+		return $domain;
 	}
 }

--- a/tests/unit/PageControllerTest.php
+++ b/tests/unit/PageControllerTest.php
@@ -3,6 +3,7 @@
 namespace OCA\Market\Tests\Unit;
 
 use OCA\Market\Controller\PageController;
+use OCP\IConfig;
 use OCP\IRequest;
 use Test\TestCase;
 
@@ -10,6 +11,8 @@ class PageControllerTest extends TestCase {
 	private $appName = 'market';
 	/** @var IRequest */
 	private $request;
+	/** @var IConfig */
+	private $config;
 	/** @var PageController */
 	private $controller;
 
@@ -17,17 +20,26 @@ class PageControllerTest extends TestCase {
 		parent::setUp();
 
 		$this->request = $this->createMock(IRequest::class);
-		$this->controller = new PageController($this->appName, $this->request);
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getSystemValue')
+			->with('appstoreurl', 'https://marketplace.owncloud.com')
+			->willReturn('https://my.appstore.example/some/path');
+		$this->controller = new PageController($this->appName, $this->request, $this->config);
+	}
+
+	private function expectedPolicy() {
+		$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$policy->addAllowedImageDomain('https://marketplace-storage.owncloud.com');
+		$policy->addAllowedImageDomain('https://marketplace-storage.staging.owncloud.services');
+		$policy->addAllowedImageDomain('http://minio:9000');
+		$policy->addAllowedImageDomain('https://my.appstore.example');
+		return $policy;
 	}
 
 	public function testIndex() {
 		$response = $this->controller->index();
 
-		$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
-		$policy->addAllowedImageDomain('https://marketplace-storage.owncloud.com');
-		$policy->addAllowedImageDomain('https://marketplace-storage.staging.owncloud.services');
-		$policy->addAllowedImageDomain('http://minio:9000');
-		$this->assertEquals($policy, $response->getContentSecurityPolicy());
+		$this->assertEquals($this->expectedPolicy(), $response->getContentSecurityPolicy());
 
 		$this->assertEquals('index', $response->getTemplateName());
 	}
@@ -35,11 +47,7 @@ class PageControllerTest extends TestCase {
 	public function testIndexHash() {
 		$response = $this->controller->indexHash();
 
-		$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
-		$policy->addAllowedImageDomain('https://marketplace-storage.owncloud.com');
-		$policy->addAllowedImageDomain('https://marketplace-storage.staging.owncloud.services');
-		$policy->addAllowedImageDomain('http://minio:9000');
-		$this->assertEquals($policy, $response->getContentSecurityPolicy());
+		$this->assertEquals($this->expectedPolicy(), $response->getContentSecurityPolicy());
 
 		$this->assertEquals('index', $response->getTemplateName());
 	}


### PR DESCRIPTION
## Summary

Prepares the **0.9.1 maintenance release** on the ownCloud 10 (oc10) compatible line, branched from the \`v0.9.0\` tag (not \`master\`, which has already advanced to 0.10.0 / ownCloud 11).

Contents:
- Cherry-pick of #1433 — *feat: allow configured appstoreurl as CSP image domain*
- Version bump \`appinfo/info.xml\` → \`0.9.1\` (oc10 deps preserved: \`min-version=10.11 max-version=10\`, PHP 7.4)
- \`CHANGELOG.md\` — new \`[0.9.1]\` section + compare link

Base branch is \`release-0.9\`. After merge this line is tagged \`v0.9.1\`, a signed tarball is built via \`make dist\`, published as a GitHub release, and submitted to \`owncloud/marketplace\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)