### PR TITLE
chore: set app author to ownCloud GmbH - a Kiteworks Company

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Please note: Since ownCloud X (10.0) every instance gets shipped with this app included. You do not need to install it separately.
 To use this application click on "Files" in the top left corner and click on "Market" (cart icon) (Administrator privileges required) </description>
 	<licence>AGPL</licence>
-	<author>Thomas Müller, Felix Heidecke, Thomas Börger, Philipp Schaffrath, Viktar Dubiniuk</author>
+	<author>ownCloud GmbH - a Kiteworks Company</author>
 	<version>0.10.0</version>
 	<default_enable/>
 	<category>tools</category>


### PR DESCRIPTION
## Summary

Sets the marketplace-facing app author in `appinfo/info.xml` to **ownCloud GmbH - a Kiteworks Company**, replacing the previous list of individual contributor names. This attributes the Market app to the ownCloud organization on marketplace.owncloud.com.

## Change

- `appinfo/info.xml` `<author>`: `Thomas Müller, Felix Heidecke, Thomas Börger, Philipp Schaffrath, Viktar Dubiniuk` → `ownCloud GmbH - a Kiteworks Company`

## Note

This controls the **displayed author name** only. The publisher that owns the listing on marketplace.owncloud.com (`https://marketplace.owncloud.com/publishers/owncloud/`) is set platform-side via the marketplace web UI and is not controlled by this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)