### PR TITLE
docs: add CHANGELOG entry for 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 [Unreleased]: https://github.com/owncloud/market/compare/v0.10.1..master
 [0.10.1]: https://github.com/owncloud/market/compare/v0.10.0..v0.10.1
-[0.10.0]: https://github.com/owncloud/market/compare/v0.9.0..v0.10.0
+[0.10.0]: https://github.com/owncloud/market/compare/v0.9.1..v0.10.0
 [0.9.1]: https://github.com/owncloud/market/compare/v0.9.0..v0.9.1
 [0.9.0]: https://github.com/owncloud/market/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/owncloud/market/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - ownCloud 11 compatible release (oc 11.0.0-rc1).
 
+## [0.9.1] - 2026-07-17
+
+### Changed
+- [#1433](https://github.com/owncloud/market/pull/1433) - feat: allow configured appstoreurl as CSP image domain
+
 ## [0.9.0] - 2024-06-04
 
 - [#1292](https://github.com/owncloud/market/pull/1292) - fix: use webpack 5
@@ -211,6 +216,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [Unreleased]: https://github.com/owncloud/market/compare/v0.10.1..master
 [0.10.1]: https://github.com/owncloud/market/compare/v0.10.0..v0.10.1
 [0.10.0]: https://github.com/owncloud/market/compare/v0.9.0..v0.10.0
+[0.9.1]: https://github.com/owncloud/market/compare/v0.9.0..v0.9.1
 [0.9.0]: https://github.com/owncloud/market/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/owncloud/market/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/owncloud/market/compare/v0.6.3...v0.7.0


### PR DESCRIPTION
The v0.9.1 maintenance release (2026-07-17, oc10-compatible line branched from v0.9.0) was published but never documented in CHANGELOG.md. This backfills its entry (and compare link).