### PR TITLE
chore: adopt the AGENTS.md convention (add CLAUDE.md symlink)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# agents.md -- Market
+# AGENTS.md -- Market
 
 ## Repository Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adopts the [AGENTS.md](https://agents.md) convention, which specifies the filename as uppercase `AGENTS.md` — the casing agent tooling looks for, and the only one found on the case-sensitive filesystems of our Linux CI runners.

- `agents.md` → `AGENTS.md` (content unchanged apart from the H1 filename)
- `CLAUDE.md` added as a **symlink** to `AGENTS.md`, so Claude Code reads the same file with no second copy to keep in sync

Opened by `scripts/sync-agents-md.py` in [owncloud/admin](https://github.com/owncloud/admin).

> On Windows clones without `core.symlinks=true`, `CLAUDE.md` materialises as a one-line text file containing `AGENTS.md`. `AGENTS.md` itself is always correct.